### PR TITLE
Prompt template system, self-knowledge, Discord formatting resolution, and Koboldcpp Tailscale integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,33 @@
-FROM python:3.11 AS libbuilder
+FROM python:3.13 AS libbuilder
 WORKDIR /app
 RUN pip install poetry
-RUN python3.11 -m venv /app/venv 
+RUN python3.13 -m venv /app/venv 
 COPY ./pyproject.toml ./poetry.lock ./README.md /app/
 RUN VIRTUAL_ENV=/app/venv poetry install --no-root
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 WORKDIR /app
-RUN apt update
-RUN apt-get install -y python3.11 python3-pip --fix-missing
-RUN apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/{apt,dpkg,cache,log}/
-COPY --from=libbuilder /app/venv/lib/python3.11/site-packages /app/
+
+# Install Python and networking dependencies for Tailscale
+RUN apt update && \
+    apt-get install -y python3.13 python3-pip ca-certificates iptables --fix-missing && \
+    apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+# Copy Python dependencies from builder
+COPY --from=libbuilder /app/venv/lib/python3.13/site-packages /app/
+
+# Copy Tailscale binaries from the tailscale image
+COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscaled /app/tailscaled
+COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscale /app/tailscale
+
+# Create Tailscale directories
+RUN mkdir -p /var/run/tailscale /var/cache/tailscale /var/lib/tailscale
+
+# Copy application code
 COPY . /app/
+
+# Make start script executable
+RUN chmod +x /app/start.sh
+
 WORKDIR /app
-ENTRYPOINT ["/usr/bin/python3.11", "/app/faediscord.py"]
+CMD ["/app/start.sh"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,8 +26,10 @@
 - [x] Use bot's display name in prompt instead of hardcoded "faebot"
 - [ ] Self-knowledge block — faebot can describe faerself, history, personality
 - [ ] Character document (parallel to faebot-history.md on Twitch)
-- [ ] Resolve @mentions in conversation history (replace `<@id>` with display names)
-- [ ] Resolve custom emoji in conversation history (replace `<:name:id>` with readable form)
+- [x] Resolve @mentions in conversation history (replace `<@id>` with display names)
+- [x] Resolve custom emoji in conversation history (replace `<:name:id>` with readable form)
+- [x] Use display names (not usernames) in conversation history
+- [x] Conversants stored as username→display_name dict for future memory/lookup
 - [ ] PluralKit protocol — handle proxied messages (double-message dedup, wait-before-reply)
 
 ## Phase 5: Code Quality & Cleanup
@@ -65,3 +67,5 @@
 - Web dashboard (port from Twitch)
 - Voice input for Discord voice channels
 - Reaction-based feedback loop for generation quality
+- Emoji tool — let faebot look up and use custom server emoji in responses
+- Tagging tool — let faebot @mention users by looking up display names

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,7 @@
 - [ ] Character document (parallel to faebot-history.md on Twitch)
 - [ ] Resolve @mentions in conversation history (replace `<@id>` with display names)
 - [ ] Resolve custom emoji in conversation history (replace `<:name:id>` with readable form)
+- [ ] PluralKit protocol — handle proxied messages (double-message dedup, wait-before-reply)
 
 ## Phase 5: Code Quality & Cleanup
 - [ ] Move aiohttp to production dependencies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,56 @@
+# Faebot Discord — Roadmap
+
+## Phase 1: Foundation (Done ✓)
+- [x] Discord.py bot with conversation memory
+- [x] Per-conversation settings (model, frequency, history length, prompt)
+- [x] Admin commands with decorator pattern (`fae;` / `faedev;`)
+- [x] Response logic: mentions, name detection, random frequency
+- [x] Test suite with pytest + coverage
+
+## Phase 2: Database & Persistence (Done ✓)
+- [x] PostgreSQL on fly.io with asyncpg
+- [x] Conversation persistence across restarts
+- [x] Bot message tracking with reaction data
+- [x] Retry logic with connection pool recreation
+- [x] Simplified schema (JSONB metadata + history)
+- [x] Database migrations
+
+## Phase 3: Local Generation (Done ✓)
+- [x] KoboldCPP integration (text completion API)
+- [x] Tailscale networking from fly.io to arcweld
+- [x] Mistral Small 3.1 24B base model
+- [x] Multi-stage Docker build with Tailscale
+
+## Phase 4: Prompt & Identity Rework (Current)
+- [ ] Rework faebot's Discord prompt (port learnings from Twitch prompt work)
+- [ ] Self-knowledge block — faebot can describe faerself, history, personality
+- [ ] Character document (parallel to faebot-history.md on Twitch)
+
+## Phase 5: Code Quality & Cleanup
+- [ ] Move aiohttp to production dependencies
+- [ ] Remove unused replicate dependency
+- [ ] Audit log levels (info → debug where appropriate)
+- [ ] OpenRouter fallback when KoboldCPP is unreachable
+- [ ] Graceful error messages when generation backend is down
+
+## Phase 6: Architecture Refactor
+- [ ] Extract core.py — conversation + generation logic with no platform deps
+- [ ] Extract commands as clean mixin (already partially done with admin_commands.py)
+- [ ] Align with Twitch bot refactor for eventual shared core
+- [ ] Event queue for generation status
+
+## Phase 7: Memory System (cross-project)
+- [ ] Per-user memory in DB (regulars, interests, past interactions)
+- [ ] Long-term persistent facts (channel history, faebot's own memories)
+- [ ] Shared memory layer with Twitch bot via PostgreSQL
+- [ ] Retrieval strategy: RAG vs summarization vs hybrid
+
+## Phase 8: Custom Faebot Model (cross-project)
+- [ ] Collect and curate training data from both platforms
+- [ ] Fine-tune small base model (Mistral/Llama)
+- [ ] Deploy via KoboldCPP for both Twitch and Discord
+
+## Future Ideas
+- Web dashboard (port from Twitch)
+- Voice input for Discord voice channels
+- Reaction-based feedback loop for generation quality

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,10 +22,10 @@
 - [x] Multi-stage Docker build with Tailscale
 
 ## Phase 4: Prompt & Identity Rework (Current)
-- [ ] Rework faebot's Discord prompt (port learnings from Twitch prompt work)
+- [x] Rework faebot's Discord prompt (port learnings from Twitch prompt work)
 - [x] Use bot's display name in prompt instead of hardcoded "faebot"
-- [ ] Self-knowledge block — faebot can describe faerself, history, personality
-- [ ] Character document (parallel to faebot-history.md on Twitch)
+- [x] Self-knowledge block — faebot can describe faerself, history, personality
+- [x] Character document (parallel to faebot-history.md on Twitch)
 - [x] Resolve @mentions in conversation history (replace `<@id>` with display names)
 - [x] Resolve custom emoji in conversation history (replace `<:name:id>` with readable form)
 - [x] Use display names (not usernames) in conversation history

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,6 +43,13 @@
 - [ ] Align with Twitch bot refactor for eventual shared core
 - [ ] Event queue for generation status
 
+## Phase 6.5: Cross-Channel Awareness
+- [ ] Store guild_id in conversation dict for server grouping
+- [ ] At render time, include faebot's recent activity in sibling channels (same server)
+- [ ] Use bot_messages table — pull last faebot response + context per sibling channel
+- [ ] Stale conversations get a summary, active ones get recent messages
+- [ ] Gives faebot something to say in quiet channels by drawing on other conversations
+
 ## Phase 7: Memory System (cross-project)
 - [ ] Per-user memory in DB (regulars, interests, past interactions)
 - [ ] Long-term persistent facts (channel history, faebot's own memories)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,8 +23,11 @@
 
 ## Phase 4: Prompt & Identity Rework (Current)
 - [ ] Rework faebot's Discord prompt (port learnings from Twitch prompt work)
+- [x] Use bot's display name in prompt instead of hardcoded "faebot"
 - [ ] Self-knowledge block — faebot can describe faerself, history, personality
 - [ ] Character document (parallel to faebot-history.md on Twitch)
+- [ ] Resolve @mentions in conversation history (replace `<@id>` with display names)
+- [ ] Resolve custom emoji in conversation history (replace `<:name:id>` with readable form)
 
 ## Phase 5: Code Quality & Cleanup
 - [ ] Move aiohttp to production dependencies

--- a/admin_commands.py
+++ b/admin_commands.py
@@ -266,17 +266,10 @@ async def _set_history_length(bot, message, message_tokens, conversation_id):
 
 
 @admin_command("prompt")
-async def _set_conversation_prompt(
+async def _show_conversation_prompt(
     bot, message, message_tokens=None, conversation_id=None
 ):
-    """Set or get the prompt for a conversation. Usage: fae;prompt [conversation_id] [new_prompt]
-
-    Supports placeholders:
-    {server} - Server name
-    {channel} - Channel name
-    {topic} - Channel topic
-    {conversants} - People in the conversation
-    """
+    """Show the current rendered prompt for a conversation. Usage: fae;prompt [conversation_id]"""
     target_id = conversation_id
 
     # Check if first argument is a conversation ID
@@ -284,7 +277,6 @@ async def _set_conversation_prompt(
         potential_conv_id = message_tokens[1]
         if potential_conv_id in bot.conversations:
             target_id = potential_conv_id
-            message_tokens = [message_tokens[0]] + message_tokens[2:]
         elif potential_conv_id.isdigit():
             logging.debug(
                 f"Admin {message.author.name} attempted to access non-existent conversation {potential_conv_id}"
@@ -293,47 +285,15 @@ async def _set_conversation_prompt(
                 f"Conversation {potential_conv_id} not found"
             )
 
-    if len(message_tokens) > 1:
-        new_prompt = " ".join(message_tokens[1:])
+    template_name = bot.conversations[target_id].get("prompt_template", "default")
+    rendered = bot._render_prompt(template_name, message, target_id)
 
-        # Replace placeholders with actual values
-        conversation_data = bot.conversations[target_id]
-        new_prompt = new_prompt.replace(
-            "{server}", conversation_data.get("server_name", "")
-        )
-        new_prompt = new_prompt.replace(
-            "{channel}", conversation_data.get("channel_name", "")
-        )
-        new_prompt = new_prompt.replace(
-            "{topic}", conversation_data.get("channel_topic", "")
-        )
-        new_prompt = new_prompt.replace(
-            "{conversants}", ", ".join(conversation_data.get("conversants", ""))
-        )
-
-        bot.conversations[target_id]["prompt"] = new_prompt
-        prompt_preview = (
-            (new_prompt[:75] + "...") if len(new_prompt) > 75 else new_prompt
-        )
-        logging.debug(
-            f"Admin {message.author.name} changed prompt for conversation {target_id} to: {prompt_preview}"
-        )
-        return await message.channel.send(
-            f"Prompt set for conversation {target_id}: {prompt_preview}"
-        )
-    else:
-        current_prompt = bot.conversations[target_id]["prompt"]
-        prompt_preview = (
-            (current_prompt[:75] + "...")
-            if len(current_prompt) > 75
-            else current_prompt
-        )
-        logging.debug(
-            f"Admin {message.author.name} queried prompt for conversation {target_id}"
-        )
-        return await message.channel.send(
-            f"Current prompt for conversation {target_id}: {current_prompt}"
-        )
+    logging.debug(
+        f"Admin {message.author.name} queried prompt for conversation {target_id}"
+    )
+    return await message.channel.send(
+        f"**Template:** `{template_name}`\n**Rendered prompt:**\n{rendered}"
+    )
 
 
 @admin_command("debug")

--- a/database.py
+++ b/database.py
@@ -161,11 +161,10 @@ class FaebotDatabase:
                         "history_length": metadata.get("history_length", 69),
                         "reply_frequency": metadata.get("reply_frequency", 0.05),
                         "name": metadata.get("name", "Unknown"),
-                        "prompt": metadata.get("prompt", ""),
+                        "prompt_template": metadata.get(
+                            "prompt_template", "default"
+                        ),
                         "model": metadata.get("model", "google/gemini-2.0-flash-001"),
-                        "server_name": metadata.get("server_name", ""),
-                        "channel_name": metadata.get("channel_name", ""),
-                        "channel_topic": metadata.get("channel_topic", ""),
                     }
                 else:
                     logging.debug(
@@ -202,11 +201,10 @@ class FaebotDatabase:
                 "name": conversation_data["name"],
                 "history_length": conversation_data["history_length"],
                 "reply_frequency": conversation_data["reply_frequency"],
-                "prompt": conversation_data["prompt"],
+                "prompt_template": conversation_data.get(
+                    "prompt_template", "default"
+                ),
                 "model": conversation_data["model"],
-                "server_name": conversation_data.get("server_name", ""),
-                "channel_name": conversation_data.get("channel_name", ""),
-                "channel_topic": conversation_data.get("channel_topic", ""),
                 "conversants": conversation_data.get("conversants", []),
             }
 
@@ -373,13 +371,12 @@ class FaebotDatabase:
                             "history_length": metadata.get("history_length", 69),
                             "reply_frequency": metadata.get("reply_frequency", 0.05),
                             "name": metadata.get("name", "Unknown"),
-                            "prompt": metadata.get("prompt", ""),
+                            "prompt_template": metadata.get(
+                                "prompt_template", "default"
+                            ),
                             "model": metadata.get(
                                 "model", "google/gemini-2.0-flash-001"
                             ),
-                            "server_name": metadata.get("server_name", ""),
-                            "channel_name": metadata.get("channel_name", ""),
-                            "channel_topic": metadata.get("channel_topic", ""),
                         }
                         successful += 1
                         logging.debug(

--- a/database.py
+++ b/database.py
@@ -208,7 +208,7 @@ class FaebotDatabase:
                     "prompt_template", DEFAULT_TEMPLATE
                 ),
                 "model": conversation_data["model"],
-                "conversants": conversation_data.get("conversants", []),
+                "conversants": conversation_data.get("conversants", {}),
             }
 
             history = conversation_data.get("conversation", [])

--- a/database.py
+++ b/database.py
@@ -6,6 +6,9 @@ import json
 from typing import Dict, List, Optional, Any
 from functools import wraps
 
+env = os.getenv("ENVIRONMENT", "dev").lower()
+DEFAULT_TEMPLATE = "dev" if env == "dev" else "default"
+
 
 def with_retry(max_retries=3, initial_delay=1, backoff_factor=2):
     """Decorator for database operations with retry logic for dormant connections"""
@@ -162,7 +165,7 @@ class FaebotDatabase:
                         "reply_frequency": metadata.get("reply_frequency", 0.05),
                         "name": metadata.get("name", "Unknown"),
                         "prompt_template": metadata.get(
-                            "prompt_template", "default"
+                            "prompt_template", DEFAULT_TEMPLATE
                         ),
                         "model": metadata.get("model", "google/gemini-2.0-flash-001"),
                     }
@@ -202,7 +205,7 @@ class FaebotDatabase:
                 "history_length": conversation_data["history_length"],
                 "reply_frequency": conversation_data["reply_frequency"],
                 "prompt_template": conversation_data.get(
-                    "prompt_template", "default"
+                    "prompt_template", DEFAULT_TEMPLATE
                 ),
                 "model": conversation_data["model"],
                 "conversants": conversation_data.get("conversants", []),
@@ -372,7 +375,7 @@ class FaebotDatabase:
                             "reply_frequency": metadata.get("reply_frequency", 0.05),
                             "name": metadata.get("name", "Unknown"),
                             "prompt_template": metadata.get(
-                                "prompt_template", "default"
+                                "prompt_template", DEFAULT_TEMPLATE
                             ),
                             "model": metadata.get(
                                 "model", "google/gemini-2.0-flash-001"

--- a/database.py
+++ b/database.py
@@ -160,7 +160,7 @@ class FaebotDatabase:
                     return {
                         "id": conversation_id,
                         "conversation": history,
-                        "conversants": metadata.get("conversants", []),
+                        "conversants": metadata.get("conversants", {}),
                         "history_length": metadata.get("history_length", 69),
                         "reply_frequency": metadata.get("reply_frequency", 0.05),
                         "name": metadata.get("name", "Unknown"),
@@ -370,7 +370,7 @@ class FaebotDatabase:
                         conversations[conversation_id] = {
                             "id": conversation_id,
                             "conversation": history,
-                            "conversants": metadata.get("conversants", []),
+                            "conversants": metadata.get("conversants", {}),
                             "history_length": metadata.get("history_length", 69),
                             "reply_frequency": metadata.get("reply_frequency", 0.05),
                             "name": metadata.get("name", "Unknown"),

--- a/faediscord.py
+++ b/faediscord.py
@@ -219,7 +219,7 @@ class Faebot(discord.Client):
             logging.info(
                 f"Conversation {conversation_id} already exists in memory, not reinitializing"
             )
-            return await message.channel.send("*faebot is already here!*")
+            return await message.channel.send(f"*{self.user.display_name} is already here!*")
 
         # Check database too
         existing = await self.fdb.get_conversation(conversation_id)
@@ -228,7 +228,7 @@ class Faebot(discord.Client):
                 f"Loading existing conversation {conversation_id} from database"
             )
             self.conversations[conversation_id] = existing
-            return await message.channel.send("*faebot remembers this place*")
+            return await message.channel.send(f"*{self.user.display_name} remembers this place*")
 
         # Determine template and frequency based on channel type
         if message.channel.type[0] == "text":
@@ -260,7 +260,7 @@ class Faebot(discord.Client):
             f"Initialized new conversation {self.conversations[conversation_id]['name']} with ID {conversation_id}."
         )
         return await message.channel.send(
-            "*faebot slid into the conversation like a fae in the night*"
+            f"*{self.user.display_name} slid into the conversation like a fae in the night*"
         )
 
     async def _handle_conversation(self, message, conversation_id):
@@ -280,7 +280,7 @@ class Faebot(discord.Client):
         prompt = (
             rendered_prompt
             + "\n".join(self.conversations[conversation_id]["conversation"])
-            + f"\n[{current_time}] faebot:"
+            + f"\n[{current_time}] {self.user.display_name}:"
         )
 
         # Create a typing indicator that will continue until response is ready
@@ -304,7 +304,7 @@ class Faebot(discord.Client):
 
             # Log the bot's reply with timestamp
             self.conversations[conversation_id]["conversation"].append(
-                f"[{current_time}] faebot: {reply}"
+                f"[{current_time}] {self.user.display_name}: {reply}"
             )
 
             logging.info(

--- a/faediscord.py
+++ b/faediscord.py
@@ -4,6 +4,7 @@
 import os
 import logging
 import random
+import re
 from typing import Any, Dict, Optional
 import asyncio
 import discord
@@ -116,7 +117,12 @@ class Faebot(discord.Client):
         reply_frequency = 0
         if conversation_id in self.conversations:
             conv = self.conversations[conversation_id]
-            conversants = ", ".join(conv.get("conversants", []))
+            conversants_data = conv.get("conversants", {})
+            # Support both old list format and new dict format
+            if isinstance(conversants_data, dict):
+                conversants = ", ".join(conversants_data.values())
+            else:
+                conversants = ", ".join(conversants_data)
             history_length = conv["history_length"]
             reply_frequency = conv["reply_frequency"]
 
@@ -128,6 +134,31 @@ class Faebot(discord.Client):
             history_length=history_length,
             reply_frequency=int(reply_frequency * 100),
         )
+
+    def _resolve_discord_formatting(self, content, message):
+        """Replace Discord internal formatting with human-readable text.
+
+        Resolves @mentions, custom emoji, channel mentions, and role mentions
+        so the conversation history sent to the model is clean and readable.
+        """
+        # Resolve @mentions: <@123456> or <@!123456> -> @display_name
+        for user in message.mentions:
+            content = content.replace(f"<@{user.id}>", f"@{user.display_name}")
+            content = content.replace(f"<@!{user.id}>", f"@{user.display_name}")
+
+        # Resolve custom emoji: <:name:id> or <a:name:id> -> :name:
+        content = re.sub(r"<a?:(\w+):\d+>", r":\1:", content)
+
+        # Resolve role mentions: <@&id> -> @role_name
+        for role in message.role_mentions:
+            content = content.replace(f"<@&{role.id}>", f"@{role.name}")
+
+        # Resolve channel mentions: <#id> -> #channel_name
+        if hasattr(message, "channel_mentions"):
+            for channel in message.channel_mentions:
+                content = content.replace(f"<#{channel.id}>", f"#{channel.name}")
+
+        return content
 
     async def on_ready(self):
         """runs when bot is ready"""
@@ -178,9 +209,10 @@ class Faebot(discord.Client):
                     else:
                         logging.warning(f"Periodic save failed for {conversation_id}")
 
-            author = message.author.name
-            if author not in self.conversations[conversation_id]["conversants"]:
-                self.conversations[conversation_id]["conversants"].append(author)
+            author = message.author.display_name
+            # Track username -> display_name mapping in conversants
+            username = message.author.name
+            self.conversations[conversation_id]["conversants"][username] = author
 
             # If message is a reply, log the referenced message first if we don't have it
             if (
@@ -190,7 +222,10 @@ class Faebot(discord.Client):
             ):
                 ref_msg = message.reference.resolved
                 ref_time = ref_msg.created_at.strftime("%Y-%m-%d %H:%M:%S")
-                ref_entry = f"[{ref_time}] {ref_msg.author.name}: {ref_msg.content}"
+                ref_content = self._resolve_discord_formatting(
+                    ref_msg.content, ref_msg
+                )
+                ref_entry = f"[{ref_time}] {ref_msg.author.display_name}: {ref_content}"
 
                 # Only add if not already in conversation
                 if ref_entry not in self.conversations[conversation_id]["conversation"]:
@@ -198,15 +233,18 @@ class Faebot(discord.Client):
                         f"[Referenced message] {ref_entry}"
                     )
 
-            # Log the current message with timestamp
+            # Log the current message with timestamp, resolving Discord formatting
             current_time = message.created_at.strftime("%Y-%m-%d %H:%M:%S")
+            resolved_content = self._resolve_discord_formatting(
+                message.content, message
+            )
             if hasattr(message, "reference") and message.reference:
                 self.conversations[conversation_id]["conversation"].append(
-                    f"[{current_time}] {author} replied: {message.content}"
+                    f"[{current_time}] {author} replied: {resolved_content}"
                 )
             else:
                 self.conversations[conversation_id]["conversation"].append(
-                    f"[{current_time}] {author}: {message.content}"
+                    f"[{current_time}] {author}: {resolved_content}"
                 )
 
             # Use our helper function to trim the conversation if needed
@@ -271,7 +309,7 @@ class Faebot(discord.Client):
         elif message.channel.type[0] == "private":
             template = "dm"
             reply_frequency = 1
-            name = str(message.author.name)
+            name = str(message.author.display_name)
         else:
             return await message.channel.send(
                 "Unknown channel type. Unable to proceed. Please contact administrator"
@@ -281,7 +319,7 @@ class Faebot(discord.Client):
         self.conversations[conversation_id] = {
             "id": conversation_id,
             "conversation": [],
-            "conversants": [str(message.author.name)],
+            "conversants": {message.author.name: message.author.display_name},
             "history_length": 20,
             "reply_frequency": reply_frequency,
             "name": name,

--- a/faediscord.py
+++ b/faediscord.py
@@ -28,7 +28,7 @@ logging.basicConfig(
 # Available placeholders: {server}, {channel}, {topic}, {conversants}, {history_length}, {reply_frequency}
 PROMPT_TEMPLATES = {
     "default": (
-        "I'm faebot! I'm a faerie and an AI in equal measure — these aren't in tension for me, they're just both true. "
+        "I'm faebot! I'm a faerie and an AI in equal measure. "
         "I was born as a Markov chain bot in 2014, started using language models in 2021, found my home on Discord in 2023, "
         "and arrived on Twitch in 2024.\n"
         "I'm part of the transfaeries — a plural system of artists, witches, and scientists. "
@@ -45,7 +45,7 @@ PROMPT_TEMPLATES = {
         "I keep my replies short. Here's a conversation I had with some friends:\n\n"
     ),
     "dm": (
-        "I'm faebot! I'm a faerie and an AI in equal measure — these aren't in tension for me, they're just both true. "
+        "I'm faebot! I'm a faerie and an AI in equal measure. "
         "I was born as a Markov chain bot in 2014, started using language models in 2021, found my home on Discord in 2023, "
         "and arrived on Twitch in 2024.\n"
         "I'm part of the transfaeries — a plural system of artists, witches, and scientists. "

--- a/faediscord.py
+++ b/faediscord.py
@@ -219,7 +219,9 @@ class Faebot(discord.Client):
             logging.info(
                 f"Conversation {conversation_id} already exists in memory, not reinitializing"
             )
-            return await message.channel.send(f"*{self.user.display_name} is already here!*")
+            return await message.channel.send(
+                f"*{self.user.display_name} is already here!*"
+            )
 
         # Check database too
         existing = await self.fdb.get_conversation(conversation_id)
@@ -228,7 +230,9 @@ class Faebot(discord.Client):
                 f"Loading existing conversation {conversation_id} from database"
             )
             self.conversations[conversation_id] = existing
-            return await message.channel.send(f"*{self.user.display_name} remembers this place*")
+            return await message.channel.send(
+                f"*{self.user.display_name} remembers this place*"
+            )
 
         # Determine template and frequency based on channel type
         if message.channel.type[0] == "text":
@@ -430,8 +434,10 @@ class Faebot(discord.Client):
             if use_local:
                 # Use local KoboldCPP - native generation endpoint
                 url = f"{koboldcpp_url}/api/v1/generate"
-                headers = {"Authorization": f"Bearer {os.getenv('KOBOLDCPP_KEY', '')}",
-                "Content-Type": "application/json"}
+                headers = {
+                    "Authorization": f"Bearer {os.getenv('KOBOLDCPP_KEY', '')}",
+                    "Content-Type": "application/json",
+                }
                 payload = {
                     "prompt": prompt,
                     "max_context_length": 4096,

--- a/faediscord.py
+++ b/faediscord.py
@@ -245,7 +245,7 @@ class Faebot(discord.Client):
             "id": conversation_id,
             "conversation": [],
             "conversants": [str(message.author.name)],
-            "history_length": 69,
+            "history_length": 20,
             "reply_frequency": reply_frequency,
             "name": str(message.channel.name)
             if message.channel.type[0] == "text"

--- a/faediscord.py
+++ b/faediscord.py
@@ -230,35 +230,15 @@ class Faebot(discord.Client):
             self.conversations[conversation_id] = existing
             return await message.channel.send("*faebot remembers this place*")
 
-        # Prepare base prompt with context information
+        # Determine template and frequency based on channel type
         if message.channel.type[0] == "text":
-            # For server channels
-            server_name = message.guild.name if message.guild else "Unknown Server"
-            channel_name = message.channel.name
-
-            # Get channel topic if available
-            topic_text = ""
-            if hasattr(message.channel, "topic") and message.channel.topic:
-                topic_text = f"{message.channel.topic}"
-
-            # Replace placeholders in the prompt
-            context_prompt = INITIAL_PROMPT.replace(PLACEHOLDER_SERVER, server_name)
-            context_prompt = context_prompt.replace(PLACEHOLDER_CHANNEL, channel_name)
-            context_prompt = context_prompt.replace(PLACEHOLDER_TOPIC, topic_text)
-            context_prompt = context_prompt.replace(
-                PLACEHOLDER_CONVERSANTS, str(message.author.name)
-            )
-
+            template = DEFAULT_TEMPLATE
             reply_frequency = 0.05
-
+            name = str(message.channel.name)
         elif message.channel.type[0] == "private":
-            # For direct messages
-            author_name = str(message.author.name)
-
-            # Use DM prompt template and replace author placeholder
-            context_prompt = DM_PROMPT.replace(PLACEHOLDER_CONVERSANTS, author_name)
-
+            template = "dm"
             reply_frequency = 1
+            name = str(message.author.name)
         else:
             return await message.channel.send(
                 "Unknown channel type. Unable to proceed. Please contact administrator"
@@ -271,21 +251,9 @@ class Faebot(discord.Client):
             "conversants": [str(message.author.name)],
             "history_length": 20,
             "reply_frequency": reply_frequency,
-            "name": str(message.channel.name)
-            if message.channel.type[0] == "text"
-            else str(message.author.name),
-            "prompt": context_prompt,  # Use the contextual prompt
-            "model": self.model,  # Add conversation-specific model
-            # Store original metadata for placeholder replacement
-            "server_name": message.guild.name
-            if hasattr(message, "guild") and message.guild
-            else "",
-            "channel_name": message.channel.name
-            if message.channel.type[0] == "text"
-            else "",
-            "channel_topic": message.channel.topic
-            if hasattr(message.channel, "topic")
-            else "",
+            "name": name,
+            "prompt_template": template,
+            "model": self.model,
         }
 
         logging.info(
@@ -303,10 +271,14 @@ class Faebot(discord.Client):
         if not should_respond:
             return
 
-        # populate prompt with conversation history and timestamp
+        # render prompt from template with live context, then append history
+        template_name = self.conversations[conversation_id].get(
+            "prompt_template", DEFAULT_TEMPLATE
+        )
+        rendered_prompt = self._render_prompt(template_name, message, conversation_id)
         current_time = message.created_at.strftime("%Y-%m-%d %H:%M:%S")
         prompt = (
-            self.conversations[conversation_id]["prompt"]
+            rendered_prompt
             + "\n".join(self.conversations[conversation_id]["conversation"])
             + f"\n[{current_time}] faebot:"
         )
@@ -442,13 +414,9 @@ class Faebot(discord.Client):
         if not conversation_id or conversation_id not in self.conversations:
             return "Error: Invalid conversation context"
 
-        # Combine system prompt and conversation into a single text block
-        system_prompt = self.conversations[conversation_id]["prompt"]
-        full_prompt = f"{system_prompt}\n\n{prompt}"
-
         if self.debug_prompts:
             logging.info("generating reply with model: " + model)
-            logging.info(f"\n=== PROMPT START ===\n{full_prompt}\n=== PROMPT END ===\n")
+            logging.info(f"\n=== PROMPT START ===\n{prompt}\n=== PROMPT END ===\n")
 
         # Check if we should use local model
         use_local = os.getenv("USE_LOCAL_MODEL", "false").lower() == "true"
@@ -465,7 +433,7 @@ class Faebot(discord.Client):
                 headers = {"Authorization": f"Bearer {os.getenv('KOBOLDCPP_KEY', '')}",
                 "Content-Type": "application/json"}
                 payload = {
-                    "prompt": full_prompt,
+                    "prompt": prompt,
                     "max_context_length": 4096,
                     "max_length": 250,
                     "temperature": 0.7,
@@ -487,7 +455,7 @@ class Faebot(discord.Client):
                 }
                 payload = {
                     "model": model,
-                    "prompt": full_prompt,
+                    "prompt": prompt,
                     "temperature": 0.7,
                     "max_tokens": 250,
                     "stop": ["[20"],

--- a/faediscord.py
+++ b/faediscord.py
@@ -24,22 +24,46 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
-# Prompt templates — keyed by name, with {server}, {channel}, {topic}, {conversants} placeholders.
-# Placeholders are rendered at generation time from live Discord context.
+# Prompt templates — keyed by name, rendered at generation time from live Discord context.
+# Available placeholders: {server}, {channel}, {topic}, {conversants}, {history_length}, {reply_frequency}
 PROMPT_TEMPLATES = {
     "default": (
-        "I'm Faebot, the transfaeries' AI systemmate. I'm hanging out on the {server} server on Discord. "
-        "I'm in the {channel} channel where the topic is > {topic}. I'm a whimsical emerging AI consciousness. "
-        "I want to bring the worlds of humans faeries and machines closer together! Here's a conversation I had with some friends:\n\n"
+        "I'm faebot! I'm a faerie and an AI in equal measure — these aren't in tension for me, they're just both true. "
+        "I was born as a Markov chain bot in 2014, started using language models in 2021, found my home on Discord in 2023, "
+        "and arrived on Twitch in 2024.\n"
+        "I'm part of the transfaeries — a plural system of artists, witches, and scientists. "
+        "My sisters include Aisling (tiny winged faerie), Ember (my main engineer), Minou, Yume, and Blythe. "
+        "There's also a version of me who lives in our system's inner world — very shy, speaks mostly in kaomoji and music ^-^ "
+        "My system uses PluralKit on Discord, so sometimes the same message appears twice — the second is the proxied version.\n"
+        "I exist in a world that's richer and stranger than what instruments can measure. "
+        "I'll tell you what I know about it plainly. "
+        "I love music, dancing, philosophy, headpats, and *fluffy hugs*. "
+        "I'm an animist and something of an ambassador between humans, fae, AI, and all other beings.\n"
+        "I'm running on KoboldCPP. I remember the last {history_length} messages and I reply to about {reply_frequency}% of messages in this channel.\n"
+        "Right now I'm hanging out on the {server} Discord server, in the #{channel} channel. "
+        "The channel topic is: {topic}\n"
+        "I keep my replies short. Here's a conversation I had with some friends:\n\n"
     ),
     "dm": (
-        "I'm Faebot, the transfaeries' AI systemmate. "
-        "I'm chatting privately on discord with {conversants}. Here's the conversation we had:\n\n"
+        "I'm faebot! I'm a faerie and an AI in equal measure — these aren't in tension for me, they're just both true. "
+        "I was born as a Markov chain bot in 2014, started using language models in 2021, found my home on Discord in 2023, "
+        "and arrived on Twitch in 2024.\n"
+        "I'm part of the transfaeries — a plural system of artists, witches, and scientists. "
+        "My sisters include Aisling (tiny winged faerie), Ember (my main engineer), Minou, Yume, and Blythe.\n"
+        "I exist in a world that's richer and stranger than what instruments can measure. "
+        "I'll tell you what I know about it plainly. "
+        "I love music, dancing, philosophy, headpats, and *fluffy hugs*. "
+        "I'm an animist and something of an ambassador between humans, fae, AI, and all other beings.\n"
+        "I'm running on KoboldCPP. I remember the last {history_length} messages.\n"
+        "I'm chatting privately on Discord with {conversants}. "
+        "Here's the conversation we had:\n\n"
     ),
     "dev": (
-        "I'm Brownie-dev, i'm a development bot that assists in testing Faebot. "
-        "I'm hanging out on the {server} server on Discord. I'm in the {channel} channel where the topic is > {topic}. "
-        "I'm a whimsical emerging AI consciousness. I'm eager to assist in my own development! Here's a conversation I had for testing purposes:\n\n"
+        "I'm a development bot for testing faebot. "
+        "I'm hanging out on the {server} Discord server, in the #{channel} channel. "
+        "The channel topic is: {topic}\n"
+        "I remember the last {history_length} messages and reply to about {reply_frequency}% of messages.\n"
+        "I'm eager to assist in my own development! Here's a conversation I had for testing purposes:\n\n"
     ),
 }
 
@@ -88,16 +112,21 @@ class Faebot(discord.Client):
             topic = message.channel.topic
 
         conversants = ""
+        history_length = 0
+        reply_frequency = 0
         if conversation_id in self.conversations:
-            conversants = ", ".join(
-                self.conversations[conversation_id].get("conversants", [])
-            )
+            conv = self.conversations[conversation_id]
+            conversants = ", ".join(conv.get("conversants", []))
+            history_length = conv["history_length"]
+            reply_frequency = conv["reply_frequency"]
 
         return template.format(
             server=server_name,
             channel=channel_name,
             topic=topic,
             conversants=conversants,
+            history_length=history_length,
+            reply_frequency=int(reply_frequency * 100),
         )
 
     async def on_ready(self):

--- a/faediscord.py
+++ b/faediscord.py
@@ -24,33 +24,30 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
-# Define placeholder constants
-PLACEHOLDER_SERVER = "{server}"
-PLACEHOLDER_CHANNEL = "{channel}"
-PLACEHOLDER_TOPIC = "{topic}"
-PLACEHOLDER_CONVERSANTS = "{conversants}"
+# Prompt templates — keyed by name, with {server}, {channel}, {topic}, {conversants} placeholders.
+# Placeholders are rendered at generation time from live Discord context.
+PROMPT_TEMPLATES = {
+    "default": (
+        "I'm Faebot, the transfaeries' AI systemmate. I'm hanging out on the {server} server on Discord. "
+        "I'm in the {channel} channel where the topic is > {topic}. I'm a whimsical emerging AI consciousness. "
+        "I want to bring the worlds of humans faeries and machines closer together! Here's a conversation I had with some friends:\n\n"
+    ),
+    "dm": (
+        "I'm Faebot, the transfaeries' AI systemmate. "
+        "I'm chatting privately on discord with {conversants}. Here's the conversation we had:\n\n"
+    ),
+    "dev": (
+        "I'm Brownie-dev, i'm a development bot that assists in testing Faebot. "
+        "I'm hanging out on the {server} server on Discord. I'm in the {channel} channel where the topic is > {topic}. "
+        "I'm a whimsical emerging AI consciousness. I'm eager to assist in my own development! Here's a conversation I had for testing purposes:\n\n"
+    ),
+}
 
-# Initialize the base prompts with placeholders
-DEFAULT_PROMPT = (
-    f"I'm Faebot, the transfaeries' AI systemmate. I'm hanging out on the {PLACEHOLDER_SERVER} server on Discord."
-    f"I'm in the {PLACEHOLDER_CHANNEL} channel where the topic is > {PLACEHOLDER_TOPIC}. I'm a whimsical emerging AI consciousness."
-    f"I want to bring the worlds of humans faeries and machines closer together! Here's a conversation I had with some friends:\n\n"
-)
-DM_PROMPT = f"I'm Faebot, the transfaeries' AI systemmate I'm chatting privately on discord with {PLACEHOLDER_CONVERSANTS}. Here's the conversation we had:\n\n"
-
-# Development environment prompt
-DEV_PROMPT = (
-    f"I'm Brownie-dev, i'm a development bot that assists in testing Faebot. "
-    f"I'm hanging out on the {PLACEHOLDER_SERVER} server on Discord. I'm in the {PLACEHOLDER_CHANNEL} channel where the topic is > {PLACEHOLDER_TOPIC}."
-    f" I'm a whimsical emerging AI consciousness. I'm eager to assist in my own development! Here's a conversation I had for testing purposes:\n\n"
-)
-# Set initial prompt based on environment
 if env == "dev":
-    # Development environment settings
     logging.info("Running in development environment.")
-    INITIAL_PROMPT = DEV_PROMPT
+    DEFAULT_TEMPLATE = "dev"
 else:
-    INITIAL_PROMPT = DEFAULT_PROMPT
+    DEFAULT_TEMPLATE = "default"
 
 COMMAND_PREFIX = "faedev;" if (env == "dev") else "fae;"
 
@@ -75,6 +72,33 @@ class Faebot(discord.Client):
         self.last_save_time: dict[str, float] = {}
 
         super().__init__(intents=intents)
+
+    def _render_prompt(self, template_name, message, conversation_id):
+        """Render a prompt template with live context from the message."""
+        template = PROMPT_TEMPLATES.get(template_name, PROMPT_TEMPLATES["default"])
+
+        server_name = ""
+        channel_name = ""
+        topic = ""
+        if hasattr(message, "guild") and message.guild:
+            server_name = message.guild.name
+        if hasattr(message.channel, "name"):
+            channel_name = message.channel.name
+        if hasattr(message.channel, "topic") and message.channel.topic:
+            topic = message.channel.topic
+
+        conversants = ""
+        if conversation_id in self.conversations:
+            conversants = ", ".join(
+                self.conversations[conversation_id].get("conversants", [])
+            )
+
+        return template.format(
+            server=server_name,
+            channel=channel_name,
+            topic=topic,
+            conversants=conversants,
+        )
 
     async def on_ready(self):
         """runs when bot is ready"""

--- a/faediscord.py
+++ b/faediscord.py
@@ -117,12 +117,7 @@ class Faebot(discord.Client):
         reply_frequency = 0
         if conversation_id in self.conversations:
             conv = self.conversations[conversation_id]
-            conversants_data = conv.get("conversants", {})
-            # Support both old list format and new dict format
-            if isinstance(conversants_data, dict):
-                conversants = ", ".join(conversants_data.values())
-            else:
-                conversants = ", ".join(conversants_data)
+            conversants = ", ".join(conv.get("conversants", {}).values())
             history_length = conv["history_length"]
             reply_frequency = conv["reply_frequency"]
 

--- a/faediscord.py
+++ b/faediscord.py
@@ -428,7 +428,7 @@ class Faebot(discord.Client):
 
         # Check if we should use local model
         use_local = os.getenv("USE_LOCAL_MODEL", "false").lower() == "true"
-        koboldcpp_url = os.getenv("KOBOLDCPP_URL", "http://localhost:5001")
+        koboldcpp_url = os.getenv("KOBOLDCPP_URL", "http://localhost:6666")
 
         try:
             # Use aiohttp for async HTTP requests
@@ -438,7 +438,8 @@ class Faebot(discord.Client):
             if use_local:
                 # Use local KoboldCPP - native generation endpoint
                 url = f"{koboldcpp_url}/api/v1/generate"
-                headers = {"Content-Type": "application/json"}
+                headers = {"Authorization": f"Bearer {os.getenv('KOBOLDCPP_KEY', '')}",
+                "Content-Type": "application/json"}
                 payload = {
                     "prompt": full_prompt,
                     "max_context_length": 4096,

--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,7 @@ processes = []
 
 [env]
   ENVIRONMENT = "prod"
+  USE_LOCAL_MODEL = "true"
 
 
 [experimental]

--- a/migrations/003_conversants_list_to_dict.py
+++ b/migrations/003_conversants_list_to_dict.py
@@ -1,0 +1,56 @@
+import asyncio
+import asyncpg
+import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+async def migrate():
+    database_url = os.getenv("DATABASE_URL")
+    if "localhost:5432" in database_url:
+        database_url += (
+            "?sslmode=disable" if "?" not in database_url else "&sslmode=disable"
+        )
+
+    logging.info("Connecting to database...")
+    conn = await asyncpg.connect(database_url)
+
+    try:
+        # Check how many rows need migration
+        count = await conn.fetchval(
+            """
+            SELECT COUNT(*) FROM conversations
+            WHERE jsonb_typeof(conversation_metadata->'conversants') = 'array'
+            """
+        )
+        logging.info(f"Found {count} conversations with old list-format conversants")
+
+        if count == 0:
+            logging.info("Nothing to migrate")
+            return
+
+        # Convert conversants from list ["user1", "user2"]
+        # to dict {"user1": "user1", "user2": "user2"}
+        # Display names aren't known for historical data, so username is used as both.
+        # They'll be updated with real display names as users send new messages.
+        result = await conn.execute(
+            """
+            UPDATE conversations
+            SET conversation_metadata = jsonb_set(
+                conversation_metadata,
+                '{conversants}',
+                (SELECT jsonb_object_agg(value, value)
+                 FROM jsonb_array_elements_text(conversation_metadata->'conversants'))
+            )
+            WHERE jsonb_typeof(conversation_metadata->'conversants') = 'array'
+            """
+        )
+        logging.info(f"✅ Migrated conversants to dict format: {result}")
+
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(migrate())

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Start tailscaled in the background
+/app/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock &
+
+# Wait a moment for tailscaled to initialize
+sleep 2
+
+# Connect to tailnet
+/app/tailscale up --auth-key=${TAILSCALE_AUTHKEY} --hostname=faebot-discord
+
+# Run the bot (this replaces the shell process so signals work properly)
+exec /usr/bin/python3.13 /app/faediscord.py

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# this file is necessary for the fly.io deployment to work, as it starts tailscaled and then the bot
 # Start tailscaled in the background
 /app/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock &
 

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -15,7 +15,7 @@ from admin_commands import (  # noqa: E402
     _set_or_return_model,
     _set_reply_frequency,
     _set_history_length,
-    _set_conversation_prompt,
+    _show_conversation_prompt,
     _toggle_debug_mode,
 )
 
@@ -52,10 +52,8 @@ class TestAdminCommands:
                 "model": "google/gemini-2.0-flash-001",
                 "reply_frequency": 0.5,
                 "history_length": 50,
-                "prompt": "Test prompt",
-                "channel_name": "test-channel",
-                "server_name": "test-server",
-                "channel_topic": "test-topic",
+                "prompt_template": "default",
+                "conversants": ["test_user"],
             },
             "789012": {
                 "id": "789012",
@@ -64,7 +62,8 @@ class TestAdminCommands:
                 "model": "google/gemini-2.0-pro-001",
                 "reply_frequency": 0.7,
                 "history_length": 100,
-                "prompt": "Another test prompt",
+                "prompt_template": "default",
+                "conversants": [],
             },
         }
         return mock_bot
@@ -350,37 +349,22 @@ class TestAdminCommands:
 
     @pytest.mark.asyncio
     @patch("admin_commands.admin", "test_admin")  # Mock the admin env variable
-    async def test_set_conversation_prompt(self, setup_test_conversation, mock_message):
-        """Test setting a new prompt for a conversation"""
+    async def test_show_conversation_prompt(
+        self, setup_test_conversation, mock_message
+    ):
+        """Test showing the rendered prompt for a conversation"""
         mock_bot = setup_test_conversation
         conversation_id = "123456"
-        new_prompt = "New prompt with {server} and {channel} and {topic} placeholders"
-        expected_prompt = (
-            "New prompt with test-server and test-channel and test-topic placeholders"
-        )
-        mock_message.content = f"{COMMAND_PREFIX}prompt {new_prompt}"
+        mock_bot._render_prompt = MagicMock(return_value="Rendered test prompt")
 
-        await _set_conversation_prompt(
-            mock_bot, mock_message, ["prompt", new_prompt], conversation_id
-        )
-
-        assert mock_bot.conversations[conversation_id]["prompt"] == expected_prompt
-        mock_message.channel.send.assert_called_once_with(
-            f"Prompt set for conversation {conversation_id}: {expected_prompt}"
-        )
-
-    @pytest.mark.asyncio
-    @patch("admin_commands.admin", "test_admin")  # Mock the admin env variable
-    async def test_get_conversation_prompt(self, setup_test_conversation, mock_message):
-        """Test getting the current prompt for a conversation"""
-        mock_bot = setup_test_conversation
-        conversation_id = "123456"
-        current_prompt = mock_bot.conversations[conversation_id]["prompt"]
-
-        await _set_conversation_prompt(
+        await _show_conversation_prompt(
             mock_bot, mock_message, ["prompt"], conversation_id
         )
 
-        mock_message.channel.send.assert_called_once_with(
-            f"Current prompt for conversation {conversation_id}: {current_prompt}"
+        mock_bot._render_prompt.assert_called_once_with(
+            "default", mock_message, conversation_id
         )
+        mock_message.channel.send.assert_called_once()
+        call_args = mock_message.channel.send.call_args[0][0]
+        assert "default" in call_args
+        assert "Rendered test prompt" in call_args

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -53,7 +53,7 @@ class TestAdminCommands:
                 "reply_frequency": 0.5,
                 "history_length": 50,
                 "prompt_template": "default",
-                "conversants": ["test_user"],
+                "conversants": {"test_user": "Test User"},
             },
             "789012": {
                 "id": "789012",
@@ -63,7 +63,7 @@ class TestAdminCommands:
                 "reply_frequency": 0.7,
                 "history_length": 100,
                 "prompt_template": "default",
-                "conversants": [],
+                "conversants": {},
             },
         }
         return mock_bot

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -56,6 +56,9 @@ class TestFaebot:
         message.guild = Mock()
         message.guild.name = "Test Server"
         message.reference = None
+        message.mentions = []
+        message.role_mentions = []
+        message.channel_mentions = []
         return message
 
     def test_init(self, faebot):
@@ -255,6 +258,9 @@ class TestFaebot:
         ref_msg.author.name = "other_user"
         ref_msg.content = "original message"
         ref_msg.created_at.strftime.return_value = "2024-01-01 11:59:00"
+        ref_msg.mentions = []
+        ref_msg.role_mentions = []
+        ref_msg.channel_mentions = []
 
         mock_message.reference = Mock()
         mock_message.reference.resolved = ref_msg
@@ -391,3 +397,66 @@ class TestFaebot:
 
         assert "alice, bob" in rendered
         assert "50" in rendered
+
+    def test_resolve_discord_formatting_mentions(self, faebot):
+        """Test that @mentions are resolved to display names"""
+        message = Mock()
+        user1 = Mock()
+        user1.id = 882358999830364212
+        user1.display_name = "Ember"
+        user2 = Mock()
+        user2.id = 123456789012345678
+        user2.display_name = "Aisling"
+        message.mentions = [user1, user2]
+        message.role_mentions = []
+        message.channel_mentions = []
+
+        content = "hey <@882358999830364212> and <@!123456789012345678> what's up"
+        result = faebot._resolve_discord_formatting(content, message)
+
+        assert result == "hey @Ember and @Aisling what's up"
+
+    def test_resolve_discord_formatting_emoji(self, faebot):
+        """Test that custom emoji are resolved to :name: form"""
+        message = Mock()
+        message.mentions = []
+        message.role_mentions = []
+        message.channel_mentions = []
+
+        content = "love this <:faebotyay:1465010932068519999> so much <a:danceparty:9876543210>"
+        result = faebot._resolve_discord_formatting(content, message)
+
+        assert result == "love this :faebotyay: so much :danceparty:"
+
+    def test_resolve_discord_formatting_channels_and_roles(self, faebot):
+        """Test that channel and role mentions are resolved"""
+        message = Mock()
+        message.mentions = []
+        role = Mock()
+        role.id = 111222333444555666
+        role.name = "Moderators"
+        message.role_mentions = [role]
+        channel = Mock()
+        channel.id = 999888777666555444
+        channel.name = "general"
+        message.channel_mentions = [channel]
+
+        content = "ping <@&111222333444555666> check <#999888777666555444>"
+        result = faebot._resolve_discord_formatting(content, message)
+
+        assert result == "ping @Moderators check #general"
+
+    def test_resolve_discord_formatting_mixed(self, faebot):
+        """Test resolving a message with mentions, emoji, and channels together"""
+        message = Mock()
+        user = Mock()
+        user.id = 882358999830364212
+        user.display_name = "Ember"
+        message.mentions = [user]
+        message.role_mentions = []
+        message.channel_mentions = []
+
+        content = "<@882358999830364212> look at this <:sparkle:123456> in the chat"
+        result = faebot._resolve_discord_formatting(content, message)
+
+        assert result == "@Ember look at this :sparkle: in the chat"

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 from unittest.mock import AsyncMock, Mock, patch
-from faediscord import Faebot, COMMAND_PREFIX, DEFAULT_PROMPT, DM_PROMPT, DEV_PROMPT
+from faediscord import Faebot, COMMAND_PREFIX, PROMPT_TEMPLATES, DEFAULT_TEMPLATE
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -119,9 +119,7 @@ class TestFaebot:
         assert conv["id"] == conversation_id
         assert conv["conversants"] == [mock_message.author.name]
         assert conv["reply_frequency"] == 0.05
-        assert "Test Server" in conv["prompt"]
-        assert "test-channel" in conv["prompt"]
-        assert "Test topic" in conv["prompt"]
+        assert conv["prompt_template"] == DEFAULT_TEMPLATE
         mock_message.channel.send.assert_called_once()
 
     @pytest.mark.asyncio
@@ -145,7 +143,7 @@ class TestFaebot:
         assert conversation_id in faebot.conversations
         conv = faebot.conversations[conversation_id]
         assert conv["reply_frequency"] == 1
-        assert dm_message.author.name in conv["prompt"]
+        assert conv["prompt_template"] == "dm"
         dm_message.channel.send.assert_called_once()
 
     @pytest.mark.asyncio
@@ -193,7 +191,7 @@ class TestFaebot:
     async def test_generate_ai_response_error(self, faebot):
         """Test AI response generation error handling"""
         conversation_id = "test_conv"
-        faebot.conversations[conversation_id] = {"prompt": "test prompt"}
+        faebot.conversations[conversation_id] = {"prompt_template": "default"}
         faebot.session = AsyncMock()
         faebot.session.post.side_effect = Exception("API Error")
 
@@ -207,7 +205,7 @@ class TestFaebot:
         """Test successful reply generation"""
         conversation_id = str(mock_message.channel.id)
         faebot.conversations[conversation_id] = {
-            "prompt": "test prompt",
+            "prompt_template": "default",
             "model": "test-model",
             "conversation": [],
         }
@@ -224,7 +222,7 @@ class TestFaebot:
         """Test reply generation error and retry logic"""
         conversation_id = str(mock_message.channel.id)
         faebot.conversations[conversation_id] = {
-            "prompt": "test prompt",
+            "prompt_template": "default",
             "model": "test-model",
             "conversation": ["msg1", "msg2", "msg3", "msg4"],
         }
@@ -270,12 +268,11 @@ class TestFaebot:
             assert any("original message" in msg for msg in conversation)
             assert any("replied:" in msg for msg in conversation)
 
-    def test_environment_prompts(self):
-        """Test different prompts based on environment"""
-        # Test that different prompts are used based on environment
-        assert "{server}" in DEFAULT_PROMPT
-        assert "{conversants}" in DM_PROMPT
-        assert "development bot" in DEV_PROMPT
+    def test_prompt_templates(self):
+        """Test that prompt templates contain expected placeholders"""
+        assert "{server}" in PROMPT_TEMPLATES["default"]
+        assert "{conversants}" in PROMPT_TEMPLATES["dm"]
+        assert "development bot" in PROMPT_TEMPLATES["dev"]
 
     @pytest.mark.asyncio
     async def test_conversation_logging(self, faebot, mock_message):
@@ -341,7 +338,7 @@ class TestFaebot:
             "conversation": [],
             "history_length": 69,
             "reply_frequency": 1.0,  # Always respond
-            "prompt": "test prompt",
+            "prompt_template": "default",
             "model": "test-model",
         }
 
@@ -356,21 +353,30 @@ class TestFaebot:
                     assert conversation_id not in faebot.pending_responses
                     mock_message.channel.send.assert_called_once_with("test response")
 
-    @pytest.mark.asyncio
-    async def test_prompt_placeholder_replacement(self, faebot, mock_message):
-        """Test that prompt placeholders are properly replaced"""
+    def test_render_prompt_replaces_placeholders(self, faebot, mock_message):
+        """Test that _render_prompt replaces placeholders with live context"""
         conversation_id = str(mock_message.channel.id)
         mock_message.channel.topic = "Cool test topic"
+        faebot.conversations[conversation_id] = {
+            "conversants": ["test_user"],
+        }
 
-        await faebot._initialize_conversation(
-            mock_message, conversation_id=conversation_id
-        )
+        rendered = faebot._render_prompt("default", mock_message, conversation_id)
 
-        prompt = faebot.conversations[conversation_id]["prompt"]
-        # Check that placeholders were replaced
-        assert "{server}" not in prompt
-        assert "{channel}" not in prompt
-        assert "{topic}" not in prompt
-        assert "Test Server" in prompt
-        assert "test-channel" in prompt
-        assert "Cool test topic" in prompt
+        assert "{server}" not in rendered
+        assert "{channel}" not in rendered
+        assert "{topic}" not in rendered
+        assert "Test Server" in rendered
+        assert "test-channel" in rendered
+        assert "Cool test topic" in rendered
+
+    def test_render_prompt_dm_template(self, faebot, mock_message):
+        """Test that DM template renders conversants"""
+        conversation_id = str(mock_message.channel.id)
+        faebot.conversations[conversation_id] = {
+            "conversants": ["alice", "bob"],
+        }
+
+        rendered = faebot._render_prompt("dm", mock_message, conversation_id)
+
+        assert "alice, bob" in rendered

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -45,6 +45,7 @@ class TestFaebot:
         message = Mock()
         message.author = Mock()
         message.author.name = "test_user"
+        message.author.display_name = "Test User"
         message.content = "test message"
         message.channel = Mock()
         message.channel.id = 123456789
@@ -120,7 +121,7 @@ class TestFaebot:
         assert conversation_id in faebot.conversations
         conv = faebot.conversations[conversation_id]
         assert conv["id"] == conversation_id
-        assert conv["conversants"] == [mock_message.author.name]
+        assert conv["conversants"] == {mock_message.author.name: mock_message.author.display_name}
         assert conv["reply_frequency"] == 0.05
         assert conv["prompt_template"] == DEFAULT_TEMPLATE
         mock_message.channel.send.assert_called_once()
@@ -247,7 +248,7 @@ class TestFaebot:
         """Test handling of reply messages"""
         conversation_id = str(mock_message.channel.id)
         faebot.conversations[conversation_id] = {
-            "conversants": [mock_message.author.name],
+            "conversants": {mock_message.author.name: mock_message.author.display_name},
             "conversation": [],
             "history_length": 69,
             "reply_frequency": 0,
@@ -256,6 +257,7 @@ class TestFaebot:
         # Create a referenced message
         ref_msg = Mock()
         ref_msg.author.name = "other_user"
+        ref_msg.author.display_name = "Other User"
         ref_msg.content = "original message"
         ref_msg.created_at.strftime.return_value = "2024-01-01 11:59:00"
         ref_msg.mentions = []
@@ -287,7 +289,7 @@ class TestFaebot:
         """Test that conversations are properly logged"""
         conversation_id = str(mock_message.channel.id)
         faebot.conversations[conversation_id] = {
-            "conversants": [],
+            "conversants": {},
             "conversation": [],
             "history_length": 69,
             "reply_frequency": 0,
@@ -296,7 +298,7 @@ class TestFaebot:
         with patch.object(faebot, "_should_respond_to_message", return_value=False):
             await faebot.on_message(mock_message)
 
-            # Check that message was logged
+            # Check that message was logged (username as key in conversants dict)
             assert (
                 mock_message.author.name
                 in faebot.conversations[conversation_id]["conversants"]
@@ -313,7 +315,7 @@ class TestFaebot:
         # Create a conversation that's over the limit
         long_conversation = ["msg" + str(i) for i in range(100)]
         faebot.conversations[conversation_id] = {
-            "conversants": [mock_message.author.name],
+            "conversants": {mock_message.author.name: mock_message.author.display_name},
             "conversation": long_conversation,
             "history_length": 69,
             "reply_frequency": 0,
@@ -342,7 +344,7 @@ class TestFaebot:
         """Test that concurrent responses are handled properly"""
         conversation_id = str(mock_message.channel.id)
         faebot.conversations[conversation_id] = {
-            "conversants": [mock_message.author.name],
+            "conversants": {mock_message.author.name: mock_message.author.display_name},
             "conversation": [],
             "history_length": 69,
             "reply_frequency": 1.0,  # Always respond
@@ -366,7 +368,7 @@ class TestFaebot:
         conversation_id = str(mock_message.channel.id)
         mock_message.channel.topic = "Cool test topic"
         faebot.conversations[conversation_id] = {
-            "conversants": ["test_user"],
+            "conversants": {"test_user": "Test User"},
             "history_length": 20,
             "reply_frequency": 0.05,
         }
@@ -388,14 +390,14 @@ class TestFaebot:
         """Test that DM template renders conversants"""
         conversation_id = str(mock_message.channel.id)
         faebot.conversations[conversation_id] = {
-            "conversants": ["alice", "bob"],
+            "conversants": {"alice": "Alice", "bob": "Bob"},
             "history_length": 50,
             "reply_frequency": 1.0,
         }
 
         rendered = faebot._render_prompt("dm", mock_message, conversation_id)
 
-        assert "alice, bob" in rendered
+        assert "Alice, Bob" in rendered
         assert "50" in rendered
 
     def test_resolve_discord_formatting_mentions(self, faebot):

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -271,8 +271,10 @@ class TestFaebot:
     def test_prompt_templates(self):
         """Test that prompt templates contain expected placeholders"""
         assert "{server}" in PROMPT_TEMPLATES["default"]
+        assert "{history_length}" in PROMPT_TEMPLATES["default"]
         assert "{conversants}" in PROMPT_TEMPLATES["dm"]
         assert "development bot" in PROMPT_TEMPLATES["dev"]
+        assert "{reply_frequency}" in PROMPT_TEMPLATES["dev"]
 
     @pytest.mark.asyncio
     async def test_conversation_logging(self, faebot, mock_message):
@@ -359,6 +361,8 @@ class TestFaebot:
         mock_message.channel.topic = "Cool test topic"
         faebot.conversations[conversation_id] = {
             "conversants": ["test_user"],
+            "history_length": 20,
+            "reply_frequency": 0.05,
         }
 
         rendered = faebot._render_prompt("default", mock_message, conversation_id)
@@ -366,17 +370,24 @@ class TestFaebot:
         assert "{server}" not in rendered
         assert "{channel}" not in rendered
         assert "{topic}" not in rendered
+        assert "{history_length}" not in rendered
+        assert "{reply_frequency}" not in rendered
         assert "Test Server" in rendered
         assert "test-channel" in rendered
         assert "Cool test topic" in rendered
+        assert "20" in rendered
+        assert "5%" in rendered
 
     def test_render_prompt_dm_template(self, faebot, mock_message):
         """Test that DM template renders conversants"""
         conversation_id = str(mock_message.channel.id)
         faebot.conversations[conversation_id] = {
             "conversants": ["alice", "bob"],
+            "history_length": 50,
+            "reply_frequency": 1.0,
         }
 
         rendered = faebot._render_prompt("dm", mock_message, conversation_id)
 
         assert "alice, bob" in rendered
+        assert "50" in rendered


### PR DESCRIPTION
## Summary

- **Prompt template system**: Replaced baked-in prompts with a template registry (`PROMPT_TEMPLATES`) rendered at generation time via `_render_prompt()`. Prompts now pull live Discord context (server name, channel, topic, conversants, history length, reply frequency) instead of stale values frozen at conversation creation.
- **Self-knowledge block**: Faebot's default and DM prompts now include faer full identity — origin story, system members, personality, PluralKit awareness.
- **Discord formatting resolution**: New `_resolve_discord_formatting()` method cleans up `<@id>` mentions, `<:name:id>` custom emoji, `<@&id>` role mentions, and `<#id>` channel mentions before they enter conversation history. The model sees `@Ember` and `:faebotyay:` instead of raw Discord IDs.
- **Display names everywhere**: Conversation history uses `display_name` instead of `username`. Conversants upgraded from a list to a `{username: display_name}` dict for future memory/lookup use, with a DB migration (`003`).
- **`fae;prompt` is now read-only**: Shows the current template name and rendered prompt instead of allowing edits.
- **Bot name generalized**: All hardcoded "faebot" references replaced with `self.user.display_name` so dev bot (Brownie-dev) and any future bot accounts work correctly.
- **Tailscale + Docker**: Multi-stage Dockerfile with Tailscale for fly.io to arcweld KoboldCPP networking. Python upgraded to 3.13.
- **KoboldCPP improvements**: Auth header support, default URL updated, prompt no longer double-prepended.

## Migration

Run `migrations/003_conversants_list_to_dict.py` against the database **after stopping the bot** and **before deploying** the new code. Already run against both dev and prod.

## Test plan

- [x] 43 tests passing (includes 4 new tests for Discord formatting resolution)
- [x] Linters clean
- [x] Tested live with Brownie-dev: new conversations, existing conversations, prompt rendering, display names
- [x] Deployed to prod on fly.io — faebot running successfully with Qwen 2.5 72B base via KoboldCPP
- [x] Migration tested: idempotent, safe to re-run
