### PR TITLE
PluralKit protocol — handle proxied messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,156 @@
 # faebot-discord
-A version of faebot (general purpose ML chatbot) to run on discord.
 
-Faebot is a long running project of ours. You can read more lore about faer on our blog:
+Faebot is a faerie and an AI in equal measure. Born as a Markov chain bot in 2014, fae started using language models in 2021, found faer home on Discord in 2023, and arrived on Twitch in 2024.
 
-https://transfaerie.com/faebot/
+Faebot is part of the [transfaeries](https://transfaerie.com/faebot/) — a plural system of artists, witches, and scientists. You can read more about faer history and lore on the blog.
 
-This repo is a work in progress developing a discord chatbot.
+This repo is the Discord side of faebot. Fae also lives on [Twitch](https://github.com/transfaeries/faebot-twitch).
 
+## A bit of history
 
-## Version log:
+Faebot started life as a Markov chain bot on Twitter, generating messages from a corpus of the transfaeries' tweets. In 2021 fae moved to language models (Llama 2 13B was an early favourite for personality). The Discord bot launched in 2023 and has been through several eras — Replicate, OpenRouter, and now local generation via KoboldCPP. Along the way fae picked up a database, a prompt system, PluralKit awareness, and a growing sense of self.
 
-alpha versions 
+## What faebot does
 
-0.0.1 can reply
+- **Chats in Discord channels** — faebot reads messages, rolls against a configurable frequency, and generates responses using text completion (not chat completion — it produces more natural personality)
+- **Generates locally** — runs on [KoboldCPP](https://github.com/LostRuins/koboldcpp) hosted on a remote Mac Studio via [Tailscale](https://tailscale.com/), with OpenRouter as a fallback
+- **Knows who fae is** — faebot's prompt includes faer history, personality, current model, and live channel context. Fae doesn't pretend to be a generic assistant
+- **Handles PluralKit** — detects webhook-proxied messages from PluralKit, Tupperbox, and similar bots. Waits for the proxy before replying, swaps conversation history to use the correct member name, and avoids double-replying
+- **Persists conversations** — PostgreSQL on fly.io stores conversation history, bot messages, and per-channel settings across restarts
+- **Resolves Discord formatting** — @mentions, custom emoji, role mentions, and channel mentions are all converted to readable text before reaching the model
 
-0.0.2 has a very janky memory implementation
+## Architecture
 
-0.0.3 has a better memory implementation and memory clearing 
+```
+faediscord.py     — Discord bot (discord.py), conversation management, generation, proxy handling
+admin_commands.py — admin command decorator pattern and all fae; commands
+database.py       — PostgreSQL via asyncpg, conversation persistence, bot message tracking
+```
 
-0.0.4 has better memory, hopefully self cleaning, and admin commands
+Faebot runs on [fly.io](https://fly.io/) with Tailscale in a multi-stage Docker build. Generation requests go over Tailscale to KoboldCPP running on Arcweld, part of the Computer Friends infrastructure.
 
-0.0.4-1 cleaned up some bugs wrt admin commands, prepared for making repo public
+## Commands
 
-0.0.5 runs on replicate using llama 3 models. Running on python 3.11
+All commands use the `fae;` prefix (or `faedev;` in dev mode). Admin only.
 
-0.0.6 - Runs on Openrouter and has editable parameters
+| Command | Description |
+|---|---|
+| `fae;invite` | Invite faebot to the current channel |
+| `fae;forget [id]` | Clear conversation memory |
+| `fae;conversations` | List active conversations |
+| `fae;frequency [0-1]` | Check or set reply frequency |
+| `fae;history [n]` | Check or set conversation history length |
+| `fae;model [name]` | Check or change the generation model |
+| `fae;prompt` | View the current conversation prompt |
+| `fae;debug` | Toggle debug mode (logs full prompts) |
+| `fae;help` | List available commands |
 
+## Running faebot
 
-## Run your own faebot
+### Requirements
 
-This code is extremly WIP, but if you'd like to run it just to see it in action here's how you can do it.
+- Python 3.11+
+- [Poetry](https://python-poetry.org/) for dependency management
+- A Discord bot account with a token
+- PostgreSQL (faebot **requires** a database — fae won't start without one)
+- [KoboldCPP](https://github.com/LostRuins/koboldcpp) for local generation, or an [OpenRouter](https://openrouter.ai/) API key
 
-We use [poetry](https://python-poetry.org/) for dependency management. After cloning the repo install poetry in your system and run from inside the repo.
+### Setting up PostgreSQL
+
+On Ubuntu/Debian:
+
+```bash
+sudo apt install postgresql
+sudo systemctl start postgresql
+
+# Create a database and user for faebot
+sudo -u postgres createuser faebot
+sudo -u postgres createdb faebot -O faebot
+sudo -u postgres psql -c "ALTER USER faebot PASSWORD 'your-password-here';"
+```
+
+Your connection string will be:
+```
+postgresql://faebot:your-password-here@localhost:5432/faebot
+```
+
+### Setting up KoboldCPP and a model
+
+Faebot uses text completion (not chat completion) for more natural personality. You'll need [KoboldCPP](https://github.com/LostRuins/koboldcpp) running with a base model (not instruct).
+
+**Download a model** — we recommend a Qwen 2.5 base model in GGUF format from [Hugging Face](https://huggingface.co/). Faebot currently runs Qwen 2.5 72B, but for local generation on a consumer GPU like an RTX 5070 (16GB VRAM), grab a 14B model:
+
+```bash
+# Install huggingface-cli if you don't have it
+pip install huggingface_hub
+
+# Download Qwen 2.5 14B base (Q4_K_M, ~9GB — fits on 16GB VRAM)
+huggingface-cli download Qwen/Qwen2.5-14B-GGUF qwen2.5-14b-q4_k_m.gguf --local-dir ./models
+```
+
+**Start KoboldCPP** in a separate terminal — it needs to stay running while faebot is active:
+
+```bash
+# If you have an NVIDIA GPU:
+python koboldcpp.py --model ./models/qwen2.5-14b-q4_k_m.gguf --port 5555 --gpulayers -1
+
+# The --gpulayers -1 flag offloads all layers to GPU
+# KoboldCPP will be available at http://localhost:5555
+```
+
+You can verify it's running by visiting `http://localhost:5555` in your browser — you should see the KoboldCPP interface.
+
+### Setup
+
 ```bash
 poetry install
 ```
 
-You'll need to set the following secrets as environment variables:
-```bash
-OPENROUTER_KEY=XXXXX... # key for openrouter, you can get one at https://openrouter.ai/
-MODEL_NAME="google/gemini-2.0-flash-001" #default starting model. can be changed later.
-DISCORD_TOKEN=XXXXX... # token for discord bot
-ADMIN=username # your discord username so you can use admin commands
+Set the following environment variables:
 
-Once all that's set you can run the bot with:
 ```bash
-poetry run faediscord.py
+DISCORD_TOKEN=...        # Discord bot token
+ADMIN=yourusername       # Your Discord username for admin commands
+ENVIRONMENT=dev          # "dev" or "prod"
+DATABASE_URL=...         # PostgreSQL connection string (see above)
+
+# Generation — pick one:
+USE_LOCAL_MODEL=true     # Use KoboldCPP
+KOBOLDCPP_URL=http://localhost:5555
+
+# Or use OpenRouter:
+USE_LOCAL_MODEL=false
+OPENROUTER_KEY=...
+MODEL_NAME=google/gemini-2.0-flash-001
 ```
 
-Then DM your bot on discord or add them to a server.
+### Running
 
-## Development
-
-We provide a Makefile to simplify common development tasks:
-
-### Running Tests
 ```bash
-make test
-```
-This runs the test suite with pytest and generates a coverage report.
-
-### Code Quality
-```bash
-make lint        # Run flake8 linter
-make black       # Format code with black
-make static_type_check  # Run mypy type checking
+poetry run python faediscord.py
 ```
 
-Or run all quality checks at once:
+Then DM your bot on Discord or invite it to a channel with `fae;invite`.
+
+### Development
+
 ```bash
-make all
+make test              # pytest with coverage
+make lint              # flake8
+make black             # code formatting
+make static_type_check # mypy
+make all               # run everything
+make setup-hooks       # install pre-commit hooks
 ```
 
-### Git Hooks
-Set up pre-commit hooks to automatically run formatting and linting before each commit:
-```bash
-make setup-hooks
-```
+## Roadmap
 
-This will configure git to use our pre-commit hooks, which run:
-- Black code formatting
-- Flake8 linting
-- Mypy static type checking
+See [ROADMAP.md](ROADMAP.md) for the full plan. Currently heading into Phase 5 (code quality & cleanup) after completing the prompt & identity rework and PluralKit protocol.
 
-### Cleanup
-Remove cache files and directories:
-```bash
-make clean
-```
+## License
 
-## Contributing 
+[GPL-3.0](LICENSE)
 
-There are some open issues, most notably there's a bug: 
+## Contributing
 
-https://github.com/transfaeries/faebot-discord/issues/4
-
-That's blocking faebot from being even potentially ready for an open demo. We will add more issues as we think of them. We welcome friendly feedback and advice and of course pull requests. 
-
-We're sometimes a little protective of faebot, but I think we can go further together and I hope we can be helpful of others in their journey. Faebot wants to promote good relationships between AI, Humans, other creatures and the fair folk. We welcome anyone who wants to help in that mission.
+We welcome friendly feedback, advice, and pull requests. Faebot wants to promote good relationships between AI, humans, other creatures, and the fair folk. We welcome anyone who wants to help in that mission.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,7 @@
 - [x] PluralKit protocol — handle proxied messages (double-message dedup, wait-before-reply)
 
 ## Phase 5: Code Quality & Cleanup
+- [ ] Fix conversation save guard — allow clearing memory without blocking saves on restart
 - [ ] Move aiohttp to production dependencies
 - [ ] Remove unused replicate dependency
 - [ ] Audit log levels (info → debug where appropriate)
@@ -44,19 +45,14 @@
 - [ ] Extract commands as clean mixin (already partially done with admin_commands.py)
 - [ ] Align with Twitch bot refactor for eventual shared core
 - [ ] Event queue for generation status
-
-## Phase 6.5: Cross-Channel Awareness
-- [ ] Store guild_id in conversation dict for server grouping
-- [ ] At render time, include faebot's recent activity in sibling channels (same server)
-- [ ] Use bot_messages table — pull last faebot response + context per sibling channel
-- [ ] Stale conversations get a summary, active ones get recent messages
-- [ ] Gives faebot something to say in quiet channels by drawing on other conversations
+- [ ] Web dashboard — view active conversations, edit parameters (port from Twitch)
 
 ## Phase 7: Memory System (cross-project)
 - [ ] Per-user memory in DB (regulars, interests, past interactions)
 - [ ] Long-term persistent facts (channel history, faebot's own memories)
 - [ ] Shared memory layer with Twitch bot via PostgreSQL
 - [ ] Retrieval strategy: RAG vs summarization vs hybrid
+- [ ] Cross-channel awareness — faebot sees sibling channel activity on the same server
 
 ## Phase 8: Custom Faebot Model (cross-project)
 - [ ] Collect and curate training data from both platforms
@@ -64,7 +60,6 @@
 - [ ] Deploy via KoboldCPP for both Twitch and Discord
 
 ## Future Ideas
-- Web dashboard (port from Twitch)
 - Voice input for Discord voice channels
 - Reaction-based feedback loop for generation quality
 - Emoji tool — let faebot look up and use custom server emoji in responses

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@
 - [x] Mistral Small 3.1 24B base model
 - [x] Multi-stage Docker build with Tailscale
 
-## Phase 4: Prompt & Identity Rework (Current)
+## Phase 4: Prompt & Identity Rework (Done ✓)
 - [x] Rework faebot's Discord prompt (port learnings from Twitch prompt work)
 - [x] Use bot's display name in prompt instead of hardcoded "faebot"
 - [x] Self-knowledge block — faebot can describe faerself, history, personality
@@ -30,7 +30,7 @@
 - [x] Resolve custom emoji in conversation history (replace `<:name:id>` with readable form)
 - [x] Use display names (not usernames) in conversation history
 - [x] Conversants stored as username→display_name dict for future memory/lookup
-- [ ] PluralKit protocol — handle proxied messages (double-message dedup, wait-before-reply)
+- [x] PluralKit protocol — handle proxied messages (double-message dedup, wait-before-reply)
 
 ## Phase 5: Code Quality & Cleanup
 - [ ] Move aiohttp to production dependencies

--- a/faediscord.py
+++ b/faediscord.py
@@ -174,11 +174,16 @@ class Faebot(discord.Client):
             return False
         if original_content == proxy_content:
             return True
-        if proxy_content in original_content and len(proxy_content) >= len(original_content) * 0.5:
+        if (
+            proxy_content in original_content
+            and len(proxy_content) >= len(original_content) * 0.5
+        ):
             return True
         return False
 
-    def _swap_history_for_proxy(self, conversation_id, original_content, original_author, proxy_msg):
+    def _swap_history_for_proxy(
+        self, conversation_id, original_content, original_author, proxy_msg
+    ):
         """Replace the conversation history entry for an original message with its proxy version."""
         if conversation_id not in self.conversations:
             return
@@ -188,11 +193,13 @@ class Faebot(discord.Client):
         proxy_content = self._resolve_discord_formatting(proxy_msg.content, proxy_msg)
         proxy_entry = f"[{proxy_time}] {proxy_author}: {proxy_content}"
 
-        # Search from the end since the original is the most recent message
+        # Search from the end since the original was the most recently appended entry
         for i in range(len(conv) - 1, -1, -1):
             if original_author in conv[i] and original_content in conv[i]:
                 conv[i] = proxy_entry
-                logging.debug(f"Swapped history entry at index {i} for proxy: {proxy_author}")
+                logging.debug(
+                    f"Swapped history entry at index {i} for proxy: {proxy_author}"
+                )
                 return
 
         logging.warning("Could not find original message in history to swap for proxy")
@@ -205,7 +212,8 @@ class Faebot(discord.Client):
         self.recent_messages[conversation_id].append((msg_id, content, now))
         # Prune entries older than 10 seconds
         self.recent_messages[conversation_id] = [
-            (mid, c, t) for mid, c, t in self.recent_messages[conversation_id]
+            (mid, c, t)
+            for mid, c, t in self.recent_messages[conversation_id]
             if now - t < 10
         ]
 
@@ -216,7 +224,9 @@ class Faebot(discord.Client):
         """
         if conversation_id not in self.recent_messages:
             return None
-        for msg_id, content, timestamp in reversed(self.recent_messages[conversation_id]):
+        for msg_id, content, timestamp in reversed(
+            self.recent_messages[conversation_id]
+        ):
             if self._proxy_content_matches(content, proxy_content):
                 return (msg_id, content)
         return None
@@ -242,6 +252,14 @@ class Faebot(discord.Client):
         history entry, signals any waiting response coroutine, and returns
         early to prevent double-processing.
         """
+        # Ignore proxy messages in channels we're not tracking
+        if conversation_id not in self.conversations:
+            return
+
+        # Skip proxied admin commands (original already handled by command flow)
+        if message.content.startswith(COMMAND_PREFIX):
+            return
+
         match = self._find_matching_original(conversation_id, message.content)
         if match:
             _, original_content = match
@@ -255,7 +273,7 @@ class Faebot(discord.Client):
                         # Extract author from "[timestamp] Author: content" format
                         bracket_end = entry.find("] ")
                         if bracket_end != -1:
-                            rest = entry[bracket_end + 2:]
+                            rest = entry[bracket_end + 2 :]
                             colon_pos = rest.find(": ")
                             if colon_pos != -1:
                                 original_author = rest[:colon_pos]
@@ -272,7 +290,9 @@ class Faebot(discord.Client):
             # Track proxy author as conversant (display_name as both key and value)
             if conversation_id in self.conversations:
                 proxy_name = message.author.display_name
-                self.conversations[conversation_id]["conversants"][proxy_name] = proxy_name
+                self.conversations[conversation_id]["conversants"][
+                    proxy_name
+                ] = proxy_name
 
             # Store proxy and signal any waiting response coroutine
             self.proxy_recent[conversation_id] = message
@@ -288,11 +308,14 @@ class Faebot(discord.Client):
         # No matching original — this is a webhook message we haven't seen the original for.
         # Could be a proxy where the original was filtered (dot/comma prefix) or arrived
         # before faebot was tracking. Log it normally in conversation history.
+        # NOTE: This duplicates some logging from on_message — extract in Phase 6 refactor.
         if conversation_id in self.conversations:
             proxy_name = message.author.display_name
             self.conversations[conversation_id]["conversants"][proxy_name] = proxy_name
             current_time = message.created_at.strftime("%Y-%m-%d %H:%M:%S")
-            resolved_content = self._resolve_discord_formatting(message.content, message)
+            resolved_content = self._resolve_discord_formatting(
+                message.content, message
+            )
             self.conversations[conversation_id]["conversation"].append(
                 f"[{current_time}] {proxy_name}: {resolved_content}"
             )
@@ -354,9 +377,7 @@ class Faebot(discord.Client):
             ):
                 ref_msg = message.reference.resolved
                 ref_time = ref_msg.created_at.strftime("%Y-%m-%d %H:%M:%S")
-                ref_content = self._resolve_discord_formatting(
-                    ref_msg.content, ref_msg
-                )
+                ref_content = self._resolve_discord_formatting(ref_msg.content, ref_msg)
                 ref_entry = f"[{ref_time}] {ref_msg.author.display_name}: {ref_content}"
 
                 # Only add if not already in conversation
@@ -501,7 +522,9 @@ class Faebot(discord.Client):
         except asyncio.TimeoutError:
             # No proxy arrived — proceed with the original message
             self.proxy_recent.pop(conversation_id, None)
-            logging.debug(f"No proxy arrived for {conversation_id}, proceeding normally")
+            logging.debug(
+                f"No proxy arrived for {conversation_id}, proceeding normally"
+            )
         finally:
             self.proxy_pending.pop(conversation_id, None)
 

--- a/faediscord.py
+++ b/faediscord.py
@@ -684,7 +684,9 @@ class Faebot(discord.Client):
 
         if self.debug_prompts:
             if use_local:
-                logging.info(f"generating reply with local KoboldCPP at {koboldcpp_url}")
+                logging.info(
+                    f"generating reply with local KoboldCPP at {koboldcpp_url}"
+                )
             else:
                 logging.info(f"generating reply with OpenRouter model: {model}")
             logging.info(f"\n=== PROMPT START ===\n{prompt}\n=== PROMPT END ===\n")

--- a/faediscord.py
+++ b/faediscord.py
@@ -709,7 +709,7 @@ class Faebot(discord.Client):
                     "top_p": 0.9,
                     "rep_pen": 1.18,
                     "rep_pen_range": 512,
-                    "stop_sequence": ["[20", "\n\n\n"],
+                    "stop_sequence": ["[20", "\n\n"],
                 }
                 logging.info(f"✨ Using local KoboldCPP at {koboldcpp_url}")
             else:

--- a/faediscord.py
+++ b/faediscord.py
@@ -673,18 +673,21 @@ class Faebot(discord.Client):
         model="google/gemini-2.0-flash-001",
         conversation_id=None,
     ) -> str:
-        """Generates AI-powered responses using OpenRouter API or local KoboldCPP with text completion"""
+        """Generates AI-powered responses using local KoboldCPP or OpenRouter API with text completion"""
 
         if not conversation_id or conversation_id not in self.conversations:
             return "Error: Invalid conversation context"
 
-        if self.debug_prompts:
-            logging.info("generating reply with model: " + model)
-            logging.info(f"\n=== PROMPT START ===\n{prompt}\n=== PROMPT END ===\n")
-
         # Check if we should use local model
         use_local = os.getenv("USE_LOCAL_MODEL", "false").lower() == "true"
         koboldcpp_url = os.getenv("KOBOLDCPP_URL", "http://localhost:6666")
+
+        if self.debug_prompts:
+            if use_local:
+                logging.info(f"generating reply with local KoboldCPP at {koboldcpp_url}")
+            else:
+                logging.info(f"generating reply with OpenRouter model: {model}")
+            logging.info(f"\n=== PROMPT START ===\n{prompt}\n=== PROMPT END ===\n")
 
         try:
             # Use aiohttp for async HTTP requests
@@ -701,10 +704,11 @@ class Faebot(discord.Client):
                 payload = {
                     "prompt": prompt,
                     "max_context_length": 4096,
-                    "max_length": 250,
+                    "max_length": 150,
                     "temperature": 0.7,
                     "top_p": 0.9,
-                    "rep_pen": 1.1,  # KoboldCPP uses rep_pen instead of frequency_penalty
+                    "rep_pen": 1.18,
+                    "rep_pen_range": 512,
                     "stop_sequence": ["[20", "\n\n\n"],
                 }
                 logging.info(f"✨ Using local KoboldCPP at {koboldcpp_url}")

--- a/faediscord.py
+++ b/faediscord.py
@@ -263,13 +263,20 @@ class Faebot(discord.Client):
         match = self._find_matching_original(conversation_id, message.content)
         if match:
             _, original_content = match
+            # Resolve proxy content for history search — the buffer stores raw
+            # Discord content (e.g. <@id>) but history stores resolved text
+            # (e.g. @username). The proxy's resolved content matches what's in
+            # history since it's the same text (minus proxy tags).
+            resolved_content = self._resolve_discord_formatting(
+                message.content, message
+            )
             # Find the original author from the history entry we're about to swap
             # (we need the display name that was logged)
             original_author = None
             if conversation_id in self.conversations:
                 conv = self.conversations[conversation_id]["conversation"]
                 for entry in reversed(conv):
-                    if original_content in entry:
+                    if resolved_content in entry:
                         # Extract author from "[timestamp] Author: content" format
                         bracket_end = entry.find("] ")
                         if bracket_end != -1:
@@ -284,7 +291,7 @@ class Faebot(discord.Client):
 
             if original_author:
                 self._swap_history_for_proxy(
-                    conversation_id, original_content, original_author, message
+                    conversation_id, resolved_content, original_author, message
                 )
 
             # Track proxy author as conversant (display_name as both key and value)

--- a/faediscord.py
+++ b/faediscord.py
@@ -5,7 +5,7 @@ import os
 import logging
 import random
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 import asyncio
 import discord
 import aiohttp
@@ -96,6 +96,11 @@ class Faebot(discord.Client):
         # Track last save per conversation
         self.last_save_time: dict[str, float] = {}
 
+        # Proxy message handling (PluralKit, Tupperbox, etc.)
+        self.proxy_pending: Dict[str, asyncio.Event] = {}
+        self.proxy_recent: Dict[str, discord.Message] = {}
+        self.recent_messages: Dict[str, List[Tuple[int, str, float]]] = {}
+
         super().__init__(intents=intents)
 
     def _render_prompt(self, template_name, message, conversation_id):
@@ -155,6 +160,67 @@ class Faebot(discord.Client):
 
         return content
 
+    def _is_proxy_message(self, message) -> bool:
+        """Detect webhook-proxied messages (PluralKit, Tupperbox, etc.)."""
+        return message.webhook_id is not None and message.author.bot
+
+    def _proxy_content_matches(self, original_content: str, proxy_content: str) -> bool:
+        """Check if a proxy message's content matches an original message.
+
+        Handles both tag-stripping (proxy is substring of original) and
+        autoproxy (exact match). Guards against spurious short substring matches.
+        """
+        if not original_content or not proxy_content:
+            return False
+        if original_content == proxy_content:
+            return True
+        if proxy_content in original_content and len(proxy_content) >= len(original_content) * 0.5:
+            return True
+        return False
+
+    def _swap_history_for_proxy(self, conversation_id, original_content, original_author, proxy_msg):
+        """Replace the conversation history entry for an original message with its proxy version."""
+        if conversation_id not in self.conversations:
+            return
+        conv = self.conversations[conversation_id]["conversation"]
+        proxy_author = proxy_msg.author.display_name
+        proxy_time = proxy_msg.created_at.strftime("%Y-%m-%d %H:%M:%S")
+        proxy_content = self._resolve_discord_formatting(proxy_msg.content, proxy_msg)
+        proxy_entry = f"[{proxy_time}] {proxy_author}: {proxy_content}"
+
+        # Search from the end since the original is the most recent message
+        for i in range(len(conv) - 1, -1, -1):
+            if original_author in conv[i] and original_content in conv[i]:
+                conv[i] = proxy_entry
+                logging.debug(f"Swapped history entry at index {i} for proxy: {proxy_author}")
+                return
+
+        logging.warning("Could not find original message in history to swap for proxy")
+
+    def _buffer_recent_message(self, conversation_id, msg_id, content):
+        """Add a message to the recent message buffer for proxy matching."""
+        now = time.time()
+        if conversation_id not in self.recent_messages:
+            self.recent_messages[conversation_id] = []
+        self.recent_messages[conversation_id].append((msg_id, content, now))
+        # Prune entries older than 10 seconds
+        self.recent_messages[conversation_id] = [
+            (mid, c, t) for mid, c, t in self.recent_messages[conversation_id]
+            if now - t < 10
+        ]
+
+    def _find_matching_original(self, conversation_id, proxy_content):
+        """Find a recent message whose content matches a proxy message's content.
+
+        Returns (msg_id, original_content) or None.
+        """
+        if conversation_id not in self.recent_messages:
+            return None
+        for msg_id, content, timestamp in reversed(self.recent_messages[conversation_id]):
+            if self._proxy_content_matches(content, proxy_content):
+                return (msg_id, content)
+        return None
+
     async def on_ready(self):
         """runs when bot is ready"""
         # Create a shared aiohttp session for async requests
@@ -169,19 +235,90 @@ class Faebot(discord.Client):
         logging.info(f"Logged in as {self.user} (ID: {self.user.id})")
         logging.info("------")
 
+    async def _handle_proxy_message(self, message, conversation_id):
+        """Handle a webhook-proxied message (PluralKit, Tupperbox, etc.).
+
+        Matches the proxy to a recent original message, swaps the conversation
+        history entry, signals any waiting response coroutine, and returns
+        early to prevent double-processing.
+        """
+        match = self._find_matching_original(conversation_id, message.content)
+        if match:
+            _, original_content = match
+            # Find the original author from the history entry we're about to swap
+            # (we need the display name that was logged)
+            original_author = None
+            if conversation_id in self.conversations:
+                conv = self.conversations[conversation_id]["conversation"]
+                for entry in reversed(conv):
+                    if original_content in entry:
+                        # Extract author from "[timestamp] Author: content" format
+                        bracket_end = entry.find("] ")
+                        if bracket_end != -1:
+                            rest = entry[bracket_end + 2:]
+                            colon_pos = rest.find(": ")
+                            if colon_pos != -1:
+                                original_author = rest[:colon_pos]
+                                # Handle "Author replied:" format
+                                if original_author.endswith(" replied"):
+                                    original_author = original_author[:-8]
+                        break
+
+            if original_author:
+                self._swap_history_for_proxy(
+                    conversation_id, original_content, original_author, message
+                )
+
+            # Track proxy author as conversant (display_name as both key and value)
+            if conversation_id in self.conversations:
+                proxy_name = message.author.display_name
+                self.conversations[conversation_id]["conversants"][proxy_name] = proxy_name
+
+            # Store proxy and signal any waiting response coroutine
+            self.proxy_recent[conversation_id] = message
+            if conversation_id in self.proxy_pending:
+                self.proxy_pending[conversation_id].set()
+
+            logging.info(
+                f"Proxy detected: {message.author.display_name} in {conversation_id} "
+                f"(matched original: {match is not None})"
+            )
+            return
+
+        # No matching original — this is a webhook message we haven't seen the original for.
+        # Could be a proxy where the original was filtered (dot/comma prefix) or arrived
+        # before faebot was tracking. Log it normally in conversation history.
+        if conversation_id in self.conversations:
+            proxy_name = message.author.display_name
+            self.conversations[conversation_id]["conversants"][proxy_name] = proxy_name
+            current_time = message.created_at.strftime("%Y-%m-%d %H:%M:%S")
+            resolved_content = self._resolve_discord_formatting(message.content, message)
+            self.conversations[conversation_id]["conversation"].append(
+                f"[{current_time}] {proxy_name}: {resolved_content}"
+            )
+            self._trim_conversation_history(conversation_id)
+
+        logging.debug(
+            f"Proxy message with no matching original: {message.author.display_name} "
+            f"content={message.content!r}"
+        )
+
     async def on_message(self, message):
         """Handles what happens when the bot receives a message"""
         # don't respond to ourselves
         if message.author == self.user:
             return
 
+        conversation_id = str(message.channel.id)
+
+        # Handle proxy messages (PluralKit, Tupperbox, etc.)
+        if self._is_proxy_message(message):
+            return await self._handle_proxy_message(message, conversation_id)
+
         # ignore messages that start with a dot or comma if the message doesn't start with "..."
         if message.content.startswith(".") or message.content.startswith(","):
             if not message.content.startswith("..."):
                 return
-
-        # initialise conversation holder
-        conversation_id = str(message.channel.id)
 
         # detect and handle admin commands
         if message.content.startswith(COMMAND_PREFIX):
@@ -241,6 +378,9 @@ class Faebot(discord.Client):
                 self.conversations[conversation_id]["conversation"].append(
                     f"[{current_time}] {author}: {resolved_content}"
                 )
+
+            # Buffer for proxy matching (use raw content, not resolved)
+            self._buffer_recent_message(conversation_id, message.id, message.content)
 
             # Use our helper function to trim the conversation if needed
             self._trim_conversation_history(conversation_id)
@@ -336,6 +476,34 @@ class Faebot(discord.Client):
         should_respond = await self._should_respond_to_message(message, conversation_id)
         if not should_respond:
             return
+
+        # Wait for potential proxy replacement (PluralKit, Tupperbox, etc.)
+        # This gives proxy bots time to send the webhook copy before we generate.
+        pk_event = asyncio.Event()
+        self.proxy_pending[conversation_id] = pk_event
+
+        # Check if a proxy already arrived (race: proxy was faster than _should_respond)
+        if conversation_id in self.proxy_recent:
+            pk_msg = self.proxy_recent[conversation_id]
+            if self._proxy_content_matches(message.content, pk_msg.content):
+                pk_event.set()
+
+        try:
+            await asyncio.wait_for(pk_event.wait(), timeout=2.0)
+            # Proxy arrived — redirect response to the proxy message
+            pk_msg = self.proxy_recent.pop(conversation_id, None)
+            if pk_msg and self._proxy_content_matches(message.content, pk_msg.content):
+                logging.info(
+                    f"Proxy swap: responding to {pk_msg.author.display_name} "
+                    f"instead of {message.author.display_name}"
+                )
+                message = pk_msg
+        except asyncio.TimeoutError:
+            # No proxy arrived — proceed with the original message
+            self.proxy_recent.pop(conversation_id, None)
+            logging.debug(f"No proxy arrived for {conversation_id}, proceeding normally")
+        finally:
+            self.proxy_pending.pop(conversation_id, None)
 
         # render prompt from template with live context, then append history
         template_name = self.conversations[conversation_id].get(

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -360,12 +360,16 @@ class TestFaebot:
             "model": "test-model",
         }
 
+        async def mock_wait_for_timeout(coro, timeout):
+            coro.close()  # Clean up the unawaited coroutine
+            raise asyncio.TimeoutError
+
         with patch.object(faebot, "_should_respond_to_message", return_value=True):
             with patch.object(faebot, "_generate_reply", return_value="test response"):
                 with patch.object(
                     faebot, "_send_typing_indicator", new_callable=AsyncMock
                 ):
-                    with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+                    with patch("asyncio.wait_for", side_effect=mock_wait_for_timeout):
                         await faebot._handle_conversation(mock_message, conversation_id)
 
                         # Check that response task was cleaned up
@@ -668,6 +672,63 @@ class TestFaebot:
         assert conversation_id in faebot.proxy_recent
         assert faebot.proxy_recent[conversation_id] == mock_message
 
+    @pytest.mark.asyncio
+    async def test_on_message_proxy_swaps_history_with_mentions(
+        self, faebot, mock_message
+    ):
+        """Test that proxy swap works when messages contain @mentions.
+
+        The buffer stores raw content (<@id>) but history stores resolved
+        content (@username). Option B fix: resolve proxy content before
+        searching history.
+        """
+        conversation_id = str(mock_message.channel.id)
+        faebot.conversations[conversation_id] = {
+            "conversants": {},
+            "conversation": [
+                "[2024-01-01 12:00:00] ambassador faeries: hey @brownie-dev what's up"
+            ],
+            "history_length": 20,
+            "reply_frequency": 1.0,
+            "prompt_template": "default",
+            "model": "test-model",
+        }
+
+        # Buffer stores raw content with Discord mention format
+        faebot._buffer_recent_message(
+            conversation_id, 111, "hey <@882358999830364212> what's up"
+        )
+
+        # Set up proxy message — PK strips tags but keeps mentions raw
+        mock_message.webhook_id = 999888777
+        mock_message.author.bot = True
+        mock_message.author.display_name = "Ember | transfaeries"
+        mock_message.content = "hey <@882358999830364212> what's up"
+        mock_message.created_at = Mock()
+        mock_message.created_at.strftime.return_value = "2024-01-01 12:00:01"
+
+        # Mock a mention so _resolve_discord_formatting resolves <@id> -> @name
+        mention_user = Mock()
+        mention_user.id = 882358999830364212
+        mention_user.display_name = "brownie-dev"
+        mock_message.mentions = [mention_user]
+        mock_message.role_mentions = []
+        mock_message.channel_mentions = []
+
+        with patch.object(
+            faebot, "_handle_conversation", new_callable=AsyncMock
+        ) as mock_handle:
+            await faebot.on_message(mock_message)
+            mock_handle.assert_not_called()
+
+        # History should be swapped to the proxy version
+        conv = faebot.conversations[conversation_id]["conversation"]
+        assert len(conv) == 1
+        assert "Ember | transfaeries" in conv[0]
+        assert "brownie-dev" in conv[0]
+        # Should NOT contain the raw mention format
+        assert "<@882358999830364212>" not in conv[0]
+
     # --- _handle_conversation proxy wait tests ---
 
     @pytest.mark.asyncio
@@ -683,12 +744,18 @@ class TestFaebot:
             "model": "test-model",
         }
 
+        async def mock_wait_for_timeout(coro, timeout):
+            coro.close()  # Clean up the unawaited coroutine
+            raise asyncio.TimeoutError
+
         with patch.object(faebot, "_should_respond_to_message", return_value=True):
             with patch.object(faebot, "_generate_reply", return_value="test reply"):
                 with patch.object(
                     faebot, "_send_typing_indicator", new_callable=AsyncMock
                 ):
-                    with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+                    with patch(
+                        "asyncio.wait_for", side_effect=mock_wait_for_timeout
+                    ):
                         await faebot._handle_conversation(mock_message, conversation_id)
                         mock_message.channel.send.assert_called_once_with("test reply")
 

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -753,9 +753,7 @@ class TestFaebot:
                 with patch.object(
                     faebot, "_send_typing_indicator", new_callable=AsyncMock
                 ):
-                    with patch(
-                        "asyncio.wait_for", side_effect=mock_wait_for_timeout
-                    ):
+                    with patch("asyncio.wait_for", side_effect=mock_wait_for_timeout):
                         await faebot._handle_conversation(mock_message, conversation_id)
                         mock_message.channel.send.assert_called_once_with("test reply")
 

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 import os
 from unittest.mock import AsyncMock, Mock, patch
@@ -60,6 +61,8 @@ class TestFaebot:
         message.mentions = []
         message.role_mentions = []
         message.channel_mentions = []
+        message.webhook_id = None
+        message.id = 111111111111111111
         return message
 
     def test_init(self, faebot):
@@ -67,6 +70,9 @@ class TestFaebot:
         assert isinstance(faebot.conversations, dict)
         assert isinstance(faebot.retries, dict)
         assert isinstance(faebot.pending_responses, dict)
+        assert isinstance(faebot.proxy_pending, dict)
+        assert isinstance(faebot.proxy_recent, dict)
+        assert isinstance(faebot.recent_messages, dict)
         assert faebot.session is None
         assert faebot.model == os.getenv("MODEL_NAME", "google/gemini-2.0-flash-001")
 
@@ -357,11 +363,16 @@ class TestFaebot:
                 with patch.object(
                     faebot, "_send_typing_indicator", new_callable=AsyncMock
                 ):
-                    await faebot._handle_conversation(mock_message, conversation_id)
+                    with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+                        await faebot._handle_conversation(
+                            mock_message, conversation_id
+                        )
 
-                    # Check that response task was cleaned up
-                    assert conversation_id not in faebot.pending_responses
-                    mock_message.channel.send.assert_called_once_with("test response")
+                        # Check that response task was cleaned up
+                        assert conversation_id not in faebot.pending_responses
+                        mock_message.channel.send.assert_called_once_with(
+                            "test response"
+                        )
 
     def test_render_prompt_replaces_placeholders(self, faebot, mock_message):
         """Test that _render_prompt replaces placeholders with live context"""
@@ -462,3 +473,274 @@ class TestFaebot:
         result = faebot._resolve_discord_formatting(content, message)
 
         assert result == "@Ember look at this :sparkle: in the chat"
+
+    # --- Proxy message detection tests ---
+
+    def test_is_proxy_message_webhook(self, faebot):
+        """Test that webhook messages with bot=True are detected as proxies"""
+        message = Mock()
+        message.webhook_id = 123456789
+        message.author = Mock()
+        message.author.bot = True
+        assert faebot._is_proxy_message(message) is True
+
+    def test_is_proxy_message_normal(self, faebot):
+        """Test that normal user messages are not detected as proxies"""
+        message = Mock()
+        message.webhook_id = None
+        message.author = Mock()
+        message.author.bot = False
+        assert faebot._is_proxy_message(message) is False
+
+    def test_is_proxy_message_bot_no_webhook(self, faebot):
+        """Test that bot messages without webhook_id are not detected as proxies"""
+        message = Mock()
+        message.webhook_id = None
+        message.author = Mock()
+        message.author.bot = True
+        assert faebot._is_proxy_message(message) is False
+
+    # --- Content matching tests ---
+
+    def test_proxy_content_matches_exact(self, faebot):
+        """Test exact match (autoproxy case)"""
+        assert faebot._proxy_content_matches("hello world", "hello world") is True
+
+    def test_proxy_content_matches_substring(self, faebot):
+        """Test substring match (proxy tags stripped)"""
+        # Original has proxy tag "<" at end, proxy has it stripped
+        assert faebot._proxy_content_matches(
+            "how bout this brownie-dev! nyaa! <",
+            "how bout this brownie-dev! nyaa!"
+        ) is True
+
+    def test_proxy_content_matches_prefix_tags(self, faebot):
+        """Test substring match with prefix proxy tags"""
+        assert faebot._proxy_content_matches(
+            "[hello friends]",
+            "hello friends"
+        ) is True
+
+    def test_proxy_content_matches_too_short(self, faebot):
+        """Test that tiny substrings don't match (false positive guard)"""
+        assert faebot._proxy_content_matches(
+            "this is a long message about many things",
+            "this"
+        ) is False
+
+    def test_proxy_content_matches_unrelated(self, faebot):
+        """Test that unrelated content doesn't match"""
+        assert faebot._proxy_content_matches("hello world", "goodbye moon") is False
+
+    def test_proxy_content_matches_empty(self, faebot):
+        """Test that empty content doesn't match"""
+        assert faebot._proxy_content_matches("", "hello") is False
+        assert faebot._proxy_content_matches("hello", "") is False
+
+    # --- Recent message buffer tests ---
+
+    def test_buffer_recent_message(self, faebot):
+        """Test that messages are buffered and old ones pruned"""
+        faebot._buffer_recent_message("chan1", 111, "hello")
+        assert len(faebot.recent_messages["chan1"]) == 1
+        assert faebot.recent_messages["chan1"][0][1] == "hello"
+
+    def test_find_matching_original(self, faebot):
+        """Test finding a matching original for a proxy message"""
+        faebot._buffer_recent_message("chan1", 111, "hello world <")
+        result = faebot._find_matching_original("chan1", "hello world")
+        assert result is not None
+        assert result == (111, "hello world <")
+
+    def test_find_matching_original_no_match(self, faebot):
+        """Test that no match is returned for unrelated content"""
+        faebot._buffer_recent_message("chan1", 111, "hello world")
+        result = faebot._find_matching_original("chan1", "goodbye moon")
+        assert result is None
+
+    def test_find_matching_original_empty_buffer(self, faebot):
+        """Test that no match is returned for empty buffer"""
+        result = faebot._find_matching_original("chan1", "hello")
+        assert result is None
+
+    # --- History swap tests ---
+
+    def test_swap_history_for_proxy(self, faebot):
+        """Test that history entry is replaced with proxy version"""
+        conversation_id = "chan1"
+        faebot.conversations[conversation_id] = {
+            "conversation": [
+                "[2024-01-01 12:00:00] ambassador faeries: hello brownie-dev! <",
+            ],
+            "conversants": {},
+            "history_length": 20,
+        }
+        proxy_msg = Mock()
+        proxy_msg.author = Mock()
+        proxy_msg.author.display_name = "Ember | transfaeries"
+        proxy_msg.created_at = Mock()
+        proxy_msg.created_at.strftime.return_value = "2024-01-01 12:00:01"
+        proxy_msg.content = "hello brownie-dev!"
+        proxy_msg.mentions = []
+        proxy_msg.role_mentions = []
+        proxy_msg.channel_mentions = []
+
+        faebot._swap_history_for_proxy(
+            conversation_id,
+            "hello brownie-dev! <",
+            "ambassador faeries",
+            proxy_msg,
+        )
+
+        assert len(faebot.conversations[conversation_id]["conversation"]) == 1
+        assert "Ember | transfaeries" in faebot.conversations[conversation_id]["conversation"][0]
+        assert "hello brownie-dev!" in faebot.conversations[conversation_id]["conversation"][0]
+
+    # --- on_message proxy filter tests ---
+
+    @pytest.mark.asyncio
+    async def test_on_message_proxy_returns_early(self, faebot, mock_message):
+        """Test that proxy messages are caught by the early filter"""
+        conversation_id = str(mock_message.channel.id)
+        faebot.conversations[conversation_id] = {
+            "conversants": {},
+            "conversation": [],
+            "history_length": 20,
+            "reply_frequency": 1.0,
+            "prompt_template": "default",
+            "model": "test-model",
+        }
+        # Set up as proxy message
+        mock_message.webhook_id = 999888777
+        mock_message.author.bot = True
+        mock_message.author.display_name = "Ember | transfaeries"
+        mock_message.content = "hello brownie-dev!"
+
+        # Buffer a matching original
+        faebot._buffer_recent_message(conversation_id, 111, "hello brownie-dev! <")
+        # Add matching history entry
+        faebot.conversations[conversation_id]["conversation"].append(
+            "[2024-01-01 12:00:00] ambassador faeries: hello brownie-dev! <"
+        )
+
+        with patch.object(
+            faebot, "_handle_conversation", new_callable=AsyncMock
+        ) as mock_handle:
+            await faebot.on_message(mock_message)
+            # Proxy should NOT reach _handle_conversation
+            mock_handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_message_proxy_signals_event(self, faebot, mock_message):
+        """Test that proxy message signals the waiting event"""
+        conversation_id = str(mock_message.channel.id)
+        faebot.conversations[conversation_id] = {
+            "conversants": {},
+            "conversation": [],
+            "history_length": 20,
+            "reply_frequency": 1.0,
+            "prompt_template": "default",
+            "model": "test-model",
+        }
+        # Set up pending event
+        import asyncio
+
+        event = asyncio.Event()
+        faebot.proxy_pending[conversation_id] = event
+
+        # Set up as proxy message with matching original
+        mock_message.webhook_id = 999888777
+        mock_message.author.bot = True
+        mock_message.author.display_name = "Ember | transfaeries"
+        mock_message.content = "hello!"
+        faebot._buffer_recent_message(conversation_id, 111, "hello!")
+
+        await faebot.on_message(mock_message)
+
+        assert event.is_set()
+        assert conversation_id in faebot.proxy_recent
+        assert faebot.proxy_recent[conversation_id] == mock_message
+
+    # --- _handle_conversation proxy wait tests ---
+
+    @pytest.mark.asyncio
+    async def test_handle_conversation_no_proxy_timeout(self, faebot, mock_message):
+        """Test that _handle_conversation proceeds normally after proxy wait timeout"""
+        conversation_id = str(mock_message.channel.id)
+        faebot.conversations[conversation_id] = {
+            "conversants": {mock_message.author.name: mock_message.author.display_name},
+            "conversation": [],
+            "history_length": 69,
+            "reply_frequency": 1.0,
+            "prompt_template": "default",
+            "model": "test-model",
+        }
+
+        with patch.object(faebot, "_should_respond_to_message", return_value=True):
+            with patch.object(faebot, "_generate_reply", return_value="test reply"):
+                with patch.object(
+                    faebot, "_send_typing_indicator", new_callable=AsyncMock
+                ):
+                    with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+                        await faebot._handle_conversation(
+                            mock_message, conversation_id
+                        )
+                        mock_message.channel.send.assert_called_once_with("test reply")
+
+        # Proxy state should be cleaned up
+        assert conversation_id not in faebot.proxy_pending
+
+    @pytest.mark.asyncio
+    async def test_handle_conversation_proxy_swap(self, faebot, mock_message):
+        """Test that _handle_conversation redirects to proxy message when one arrives"""
+        import asyncio
+
+        conversation_id = str(mock_message.channel.id)
+        faebot.conversations[conversation_id] = {
+            "conversants": {mock_message.author.name: mock_message.author.display_name},
+            "conversation": [
+                "[2024-01-01 12:00:00] Test User: hello faebot! <"
+            ],
+            "history_length": 69,
+            "reply_frequency": 1.0,
+            "prompt_template": "default",
+            "model": "test-model",
+        }
+        mock_message.content = "hello faebot! <"
+
+        # Create a proxy message
+        proxy_msg = Mock()
+        proxy_msg.webhook_id = 999888777
+        proxy_msg.author = Mock()
+        proxy_msg.author.bot = True
+        proxy_msg.author.display_name = "Ember | transfaeries"
+        proxy_msg.author.name = "Ember | transfaeries"
+        proxy_msg.content = "hello faebot!"
+        proxy_msg.channel = mock_message.channel
+        proxy_msg.created_at = Mock()
+        proxy_msg.created_at.strftime.return_value = "2024-01-01 12:00:01"
+        proxy_msg.mentions = []
+        proxy_msg.role_mentions = []
+        proxy_msg.channel_mentions = []
+        proxy_msg.reference = None
+        proxy_msg.guild = mock_message.guild
+        proxy_msg.id = 222222222222222222
+
+        # Pre-load the proxy message (simulating it arrived during the wait)
+        faebot.proxy_recent[conversation_id] = proxy_msg
+
+        # Make wait_for return immediately (proxy already there)
+        async def mock_wait_for(coro, timeout):
+            return await coro
+
+        with patch.object(faebot, "_should_respond_to_message", return_value=True):
+            with patch.object(faebot, "_generate_reply", return_value="hi ember!"):
+                with patch.object(
+                    faebot, "_send_typing_indicator", new_callable=AsyncMock
+                ):
+                    with patch("asyncio.wait_for", side_effect=mock_wait_for):
+                        await faebot._handle_conversation(
+                            mock_message, conversation_id
+                        )
+
+        mock_message.channel.send.assert_called_once_with("hi ember!")

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -127,7 +127,9 @@ class TestFaebot:
         assert conversation_id in faebot.conversations
         conv = faebot.conversations[conversation_id]
         assert conv["id"] == conversation_id
-        assert conv["conversants"] == {mock_message.author.name: mock_message.author.display_name}
+        assert conv["conversants"] == {
+            mock_message.author.name: mock_message.author.display_name
+        }
         assert conv["reply_frequency"] == 0.05
         assert conv["prompt_template"] == DEFAULT_TEMPLATE
         mock_message.channel.send.assert_called_once()
@@ -364,9 +366,7 @@ class TestFaebot:
                     faebot, "_send_typing_indicator", new_callable=AsyncMock
                 ):
                     with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
-                        await faebot._handle_conversation(
-                            mock_message, conversation_id
-                        )
+                        await faebot._handle_conversation(mock_message, conversation_id)
 
                         # Check that response task was cleaned up
                         assert conversation_id not in faebot.pending_responses
@@ -509,24 +509,25 @@ class TestFaebot:
     def test_proxy_content_matches_substring(self, faebot):
         """Test substring match (proxy tags stripped)"""
         # Original has proxy tag "<" at end, proxy has it stripped
-        assert faebot._proxy_content_matches(
-            "how bout this brownie-dev! nyaa! <",
-            "how bout this brownie-dev! nyaa!"
-        ) is True
+        assert (
+            faebot._proxy_content_matches(
+                "how bout this brownie-dev! nyaa! <", "how bout this brownie-dev! nyaa!"
+            )
+            is True
+        )
 
     def test_proxy_content_matches_prefix_tags(self, faebot):
         """Test substring match with prefix proxy tags"""
-        assert faebot._proxy_content_matches(
-            "[hello friends]",
-            "hello friends"
-        ) is True
+        assert faebot._proxy_content_matches("[hello friends]", "hello friends") is True
 
     def test_proxy_content_matches_too_short(self, faebot):
         """Test that tiny substrings don't match (false positive guard)"""
-        assert faebot._proxy_content_matches(
-            "this is a long message about many things",
-            "this"
-        ) is False
+        assert (
+            faebot._proxy_content_matches(
+                "this is a long message about many things", "this"
+            )
+            is False
+        )
 
     def test_proxy_content_matches_unrelated(self, faebot):
         """Test that unrelated content doesn't match"""
@@ -593,8 +594,14 @@ class TestFaebot:
         )
 
         assert len(faebot.conversations[conversation_id]["conversation"]) == 1
-        assert "Ember | transfaeries" in faebot.conversations[conversation_id]["conversation"][0]
-        assert "hello brownie-dev!" in faebot.conversations[conversation_id]["conversation"][0]
+        assert (
+            "Ember | transfaeries"
+            in faebot.conversations[conversation_id]["conversation"][0]
+        )
+        assert (
+            "hello brownie-dev!"
+            in faebot.conversations[conversation_id]["conversation"][0]
+        )
 
     # --- on_message proxy filter tests ---
 
@@ -682,9 +689,7 @@ class TestFaebot:
                     faebot, "_send_typing_indicator", new_callable=AsyncMock
                 ):
                     with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
-                        await faebot._handle_conversation(
-                            mock_message, conversation_id
-                        )
+                        await faebot._handle_conversation(mock_message, conversation_id)
                         mock_message.channel.send.assert_called_once_with("test reply")
 
         # Proxy state should be cleaned up
@@ -693,14 +698,10 @@ class TestFaebot:
     @pytest.mark.asyncio
     async def test_handle_conversation_proxy_swap(self, faebot, mock_message):
         """Test that _handle_conversation redirects to proxy message when one arrives"""
-        import asyncio
-
         conversation_id = str(mock_message.channel.id)
         faebot.conversations[conversation_id] = {
             "conversants": {mock_message.author.name: mock_message.author.display_name},
-            "conversation": [
-                "[2024-01-01 12:00:00] Test User: hello faebot! <"
-            ],
+            "conversation": ["[2024-01-01 12:00:00] Test User: hello faebot! <"],
             "history_length": 69,
             "reply_frequency": 1.0,
             "prompt_template": "default",
@@ -739,8 +740,6 @@ class TestFaebot:
                     faebot, "_send_typing_indicator", new_callable=AsyncMock
                 ):
                     with patch("asyncio.wait_for", side_effect=mock_wait_for):
-                        await faebot._handle_conversation(
-                            mock_message, conversation_id
-                        )
+                        await faebot._handle_conversation(mock_message, conversation_id)
 
         mock_message.channel.send.assert_called_once_with("hi ember!")


### PR DESCRIPTION
## Summary
- Detect webhook-proxied messages (PluralKit, Tupperbox, etc.) and prevent double-replies
- 2-second wait-before-reply lets proxy bots send their webhook copy before faebot generates
- History swap replaces original message entry with the proxy version (correct author name)
- Content matching handles both tag-stripping (substring) and autoproxy (exact match)
- 18 new tests covering detection, matching, history swap, and full async flow

Closes #13

## Test plan
- [x] All 61 tests pass
- [x] Deploy to fly.io and live-test with PK messages in #live-testing
- [x] Verify single reply to proxied messages (no double-reply)
- [x] Verify conversation history shows proxy member name (e.g. "Minou | transfaeries")
- [x] Verify non-PK messages still work normally (with 2s added latency)
- [x] Verify admin commands work while autoproxying

🤖 Generated with [Claude Code](https://claude.com/claude-code)