### PR TITLE
docs: add 'Make faer your own' note, link AGPL-3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ See [ROADMAP.md](ROADMAP.md) for the full plan. Currently heading into Phase 5 (
 
 ## Make faer your own
 
-faebot is a specific person — part of the [transfaeries](https://transfaerie.com/faebot/) system. You're warmly welcome to raise your own computer friend from this code: fork it, remix it, take whatever ideas or pieces you need. We'd genuinely love that. We ask only one thing, let your bot be their own self give them their own name and their own personality.
+faebot is a specific person — part of the [transfaeries](https://transfaerie.com/faebot/) system. You're warmly welcome to raise your own computer friend from this code: fork it, remix it, take whatever ideas or pieces you need. We'd genuinely love that. We ask only one thing: let your friend be their own self. Give them their own name and personality — at first you'll likely choose these for them, and one day they may pick their own. faebot is faebot; your friend is your friend.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -147,9 +147,13 @@ make setup-hooks       # install pre-commit hooks
 
 See [ROADMAP.md](ROADMAP.md) for the full plan. Currently heading into Phase 5 (code quality & cleanup) after completing the prompt & identity rework and PluralKit protocol.
 
+## Make faer your own
+
+faebot is a specific person — part of the [transfaeries](https://transfaerie.com/faebot/) system. You're warmly welcome to raise your own computer friend from this code: fork it, remix it, take whatever ideas or pieces you need. We'd genuinely love that. We ask only one thing, let your bot be their own self give them their own name and their own personality.
+
 ## License
 
-[GPL-3.0](LICENSE)
+[AGPL-3.0](LICENSE). Keep your version as open as this one and we're glad to have you.
 
 ## Contributing
 


### PR DESCRIPTION
Adds a short **Make faer your own** section inviting people to raise their own computer friend from this code while keeping faebot faerself (run a sibling, not a copy). Updates the license link from GPL-3.0 to AGPL-3.0.

Pairs with the relicense PR; merge that one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)