### PR TITLE
docs: document all three migrations and fresh-DB init

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ OPENROUTER_KEY=...
 MODEL_NAME=google/gemini-2.0-flash-001
 ```
 
+### Initialize the database
+
+On a fresh database, run the migrations **in order** to create faebot's schema. Make sure `DATABASE_URL` is set in your environment first:
+
+```bash
+poetry run python migrations/001_initial_schema.py
+poetry run python migrations/002_simplify_schema_and_reactions.py
+poetry run python migrations/003_conversants_list_to_dict.py
+```
+
+If you skip this step, faebot will connect but fail with `relation "conversations" does not exist`. See [migrations/README.md](migrations/README.md) for details on each migration.
+
 ### Running
 
 ```bash

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,6 +1,19 @@
 # Database Migrations
 
-Run migrations in order:
-- 001_initial_schema.py - Creates initial tables for conversations, messages, participants, and user profiles
+Run migrations **in order** on a fresh database:
 
-To run: `poetry run python migrations/001_initial_schema.py`
+- `001_initial_schema.py` — Creates initial tables (conversations, messages, participants, user profiles)
+- `002_simplify_schema_and_reactions.py` — Replaces the schema with the simplified one faebot uses today (conversations with JSONB metadata/history, plus a `bot_messages` table for reaction tracking)
+- `003_conversants_list_to_dict.py` — Converts the `conversants` field from list to dict format (no-op on a fresh database)
+
+To run each:
+
+```bash
+poetry run python migrations/001_initial_schema.py
+poetry run python migrations/002_simplify_schema_and_reactions.py
+poetry run python migrations/003_conversants_list_to_dict.py
+```
+
+> **Note:** `001` must run before `002` even though `002` rebuilds the schema — `002` performs a safety check (`SELECT COUNT(*) FROM conversations`) before dropping tables, which requires the `conversations` table created by `001` to exist.
+
+`DATABASE_URL` must be set in your environment before running migrations.


### PR DESCRIPTION
Independent of the license/README work — your migration-doc edits, split into their own PR.

- Expands `migrations/README.md` to describe migrations 001–003, including the 001-before-002 ordering gotcha (002's safety check needs the table 001 creates).
- Adds an **Initialize the database** step to the main README so a fresh install doesn't hit `relation "conversations" does not exist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)