### PR TITLE
spike01: in-process capture tap — raw events to captured_events (capture-only)

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -1,0 +1,322 @@
+"""Spike 01 (faebot-core) — Discord capture tap.
+
+A *thin, faithful, opt-in, maximalist* recorder that appends raw Discord events
+to the `captured_events` Postgres table so we can transduce them into faebot-core
+`Observation`s offline (in faebot-private/snippets/discord/). It is the sibling of
+faebot-twitch's capture tap and the in-process successor to the standalone
+spike01_listener: record everything the surface gives us, reason about none of it
+here — reconciliation is faebot's cognition, not the adapter's.
+
+Design rules (load-bearing — this runs inside the LIVE bot on fly):
+  * **Opt-in.** Capture happens only when SPIKE_CAPTURE is set (any non-empty
+    value). Unset = every function is a no-op, so the live bot is completely
+    unaffected unless we deliberately turn it on. SPIKE_CAPTURE_RAW=0 additionally
+    disables the raw gateway-frame catch-all if its volume gets silly.
+  * **Never breaks the bot.** Every extraction + write is wrapped; failures are
+    swallowed and logged at debug. Writes are fired as background tasks so a slow
+    or dormant database can never delay faebot's reply path.
+  * **Faithful & maximalist.** We record raw fields verbatim, drop nothing, and
+    interpret nothing. The raw socket catch-all captures gateway events we never
+    coded for — the bitter-lesson discipline.
+  * **Capture-only.** Nothing recorded here feeds the prompt the live bot sends
+    to its model. This is corpus accumulation for offline spikes, not cognition.
+  * **Append-only.** Rows are inserted, never updated; the BIGSERIAL id is the
+    watermark the offline pull script pages through.
+
+Payload shapes deliberately match spike01_listener's JSONL rows, so the offline
+pull script can reconstruct byte-shape-identical lines for transduce.py.
+"""
+
+import asyncio
+import datetime
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+
+
+CAPTURE_ENABLED = bool(os.getenv("SPIKE_CAPTURE", ""))
+RAW_ENABLED = CAPTURE_ENABLED and os.getenv("SPIKE_CAPTURE_RAW", "1") != "0"
+
+# The database handle is injected at startup (see init) to avoid a circular import.
+_database: Optional[Any] = None
+
+# Fire-and-forget insert tasks — referenced here so they aren't garbage-collected.
+_pending_writes: set = set()
+
+
+def init(database) -> None:
+    """Give the tap its database handle (a FaebotDatabase). Called once at startup."""
+    global _database
+    _database = database
+    logging.info(
+        "capture: %s (raw catch-all: %s)",
+        "ENABLED — recording to captured_events" if CAPTURE_ENABLED else "off",
+        "on" if RAW_ENABLED else "off",
+    )
+
+
+def is_enabled() -> bool:
+    return CAPTURE_ENABLED and _database is not None
+
+
+# --- the writer ---------------------------------------------------------------
+
+
+def record(kind: str, payload: Dict[str, Any]) -> None:
+    """Queue one raw event row. `kind` names the surface event (message,
+    message_edit, faebot_message, socket_raw, ...); `payload` carries the raw
+    surface attributes verbatim. The timestamp is stamped here, synchronously,
+    so ordering survives the background write."""
+    if not is_enabled():
+        return
+    try:
+        captured_at = datetime.datetime.now(datetime.timezone.utc)
+        payload_json = json.dumps(payload, ensure_ascii=False, default=str)
+        task = asyncio.get_running_loop().create_task(
+            _write(kind, captured_at, payload_json)
+        )
+        _pending_writes.add(task)
+        task.add_done_callback(_pending_writes.discard)
+    except Exception as error:
+        # Capture must never disturb the bot — log and move on.
+        logging.debug(
+            "capture record failed (%s): %s: %s", kind, type(error).__name__, error
+        )
+
+
+async def _write(kind: str, captured_at: datetime.datetime, payload_json: str) -> None:
+    try:
+        if _database is None:  # is_enabled() already checked; this appeases mypy
+            return
+        await _database.save_captured_event(kind, captured_at, payload_json)
+    except Exception as error:
+        logging.debug(
+            "capture write failed (%s): %s: %s", kind, type(error).__name__, error
+        )
+
+
+# --- serialisers (lifted from spike01_listener — proven shapes) -----------------
+
+
+def serialize_user(user: Any) -> Optional[Dict[str, Any]]:
+    if user is None:
+        return None
+    return {
+        "id": getattr(user, "id", None),
+        "name": getattr(user, "name", None),
+        "display_name": getattr(user, "display_name", None),
+        "bot": getattr(user, "bot", None),
+        "system": getattr(user, "system", None),
+    }
+
+
+def serialize_channel(channel: Any) -> Optional[Dict[str, Any]]:
+    if channel is None:
+        return None
+    return {
+        "id": getattr(channel, "id", None),
+        "name": getattr(channel, "name", None),
+        "type": str(getattr(channel, "type", None)),
+        "guild_id": getattr(getattr(channel, "guild", None), "id", None),
+    }
+
+
+def serialize_emoji(emoji: Any) -> Dict[str, Any]:
+    return {
+        "name": getattr(emoji, "name", None),
+        "id": getattr(emoji, "id", None),
+        "custom": getattr(emoji, "id", None) is not None,
+    }
+
+
+def serialize_message(message: Any) -> Dict[str, Any]:
+    return {
+        "id": message.id,
+        "content": message.content,
+        "author": serialize_user(message.author),
+        "channel": serialize_channel(message.channel),
+        "guild_id": getattr(message.guild, "id", None),
+        "created_at": message.created_at.isoformat() if message.created_at else None,
+        "edited_at": message.edited_at.isoformat() if message.edited_at else None,
+        # webhook_id is set for PluralKit / webhook reposts — the proxy churn.
+        "webhook_id": message.webhook_id,
+        "type": str(message.type),
+        "reply_to": getattr(message.reference, "message_id", None)
+        if message.reference
+        else None,
+        "mentions": [user.id for user in message.mentions],
+        "role_mentions": [role.id for role in message.role_mentions],
+        "channel_mentions": [channel.id for channel in message.channel_mentions],
+        "mention_everyone": message.mention_everyone,
+        "attachments": [
+            {
+                "filename": attachment.filename,
+                "content_type": attachment.content_type,
+                "size": attachment.size,
+            }
+            for attachment in message.attachments
+        ],
+        "embeds": len(message.embeds),
+        "stickers": [sticker.name for sticker in message.stickers],
+        "reactions": [
+            {"emoji": str(reaction.emoji), "count": reaction.count}
+            for reaction in message.reactions
+        ],
+    }
+
+
+# --- recorders (one per surface event; all no-ops unless enabled) ---------------
+
+
+def record_message(message: Any) -> None:
+    """Every incoming message, called at the very top of on_message — BEFORE the
+    self-check and all filtering, so we also capture faebot's own echo (the
+    from-the-outside view of faer speech), proxy webhooks, and dotted messages."""
+    if not is_enabled():
+        return
+    try:
+        record("message", {"message": serialize_message(message)})
+    except Exception as error:
+        logging.debug("capture message failed: %s: %s", type(error).__name__, error)
+
+
+def record_message_edit(payload: Any) -> None:
+    """Raw edit event — fires even for uncached messages. The gateway payload
+    carries the new content; cached_before (when we have it) carries the old."""
+    if not is_enabled():
+        return
+    try:
+        cached = payload.cached_message
+        record(
+            "message_edit",
+            {
+                "message_id": payload.message_id,
+                "channel_id": payload.channel_id,
+                "guild_id": payload.guild_id,
+                "cached_before": serialize_message(cached) if cached else None,
+                "raw_data": payload.data,
+            },
+        )
+    except Exception as error:
+        logging.debug("capture edit failed: %s: %s", type(error).__name__, error)
+
+
+def record_message_delete(payload: Any) -> None:
+    """Raw delete event — the PluralKit churn's deleted originals show up here
+    (their content was already captured at on_message time, so an id suffices)."""
+    if not is_enabled():
+        return
+    try:
+        cached = payload.cached_message
+        record(
+            "message_delete",
+            {
+                "message_id": payload.message_id,
+                "channel_id": payload.channel_id,
+                "guild_id": payload.guild_id,
+                "cached_before": serialize_message(cached) if cached else None,
+            },
+        )
+    except Exception as error:
+        logging.debug("capture delete failed: %s: %s", type(error).__name__, error)
+
+
+def record_reaction(payload: Any, action: str) -> None:
+    """Raw reaction add/remove. `action` is "reaction_add" or "reaction_remove"."""
+    if not is_enabled():
+        return
+    try:
+        record(
+            action,
+            {
+                "user_id": payload.user_id,
+                "message_id": payload.message_id,
+                "channel_id": payload.channel_id,
+                "guild_id": payload.guild_id,
+                "emoji": serialize_emoji(payload.emoji),
+            },
+        )
+    except Exception as error:
+        logging.debug("capture reaction failed: %s: %s", type(error).__name__, error)
+
+
+def record_typing(channel: Any, user: Any, when: Any) -> None:
+    """The typing signal — noise, but real lived signal (see spike 01 findings)."""
+    if not is_enabled():
+        return
+    try:
+        record(
+            "typing",
+            {
+                "guild_id": getattr(getattr(channel, "guild", None), "id", None),
+                "channel": serialize_channel(channel),
+                "user": serialize_user(user),
+                "when": when.isoformat() if hasattr(when, "isoformat") else str(when),
+            },
+        )
+    except Exception as error:
+        logging.debug("capture typing failed: %s: %s", type(error).__name__, error)
+
+
+def record_member(member: Any, action: str) -> None:
+    """Member join/leave. `action` is "member_join" or "member_remove"."""
+    if not is_enabled():
+        return
+    try:
+        record(
+            action,
+            {"guild_id": member.guild.id, "member": serialize_user(member)},
+        )
+    except Exception as error:
+        logging.debug("capture member failed: %s: %s", type(error).__name__, error)
+
+
+def record_faebot_message(
+    sent_message: Any,
+    conversation_id: str,
+    prompt: str,
+    model: str,
+    context: Any,
+) -> None:
+    """faebot's own generated reply, captured at the send point — the only place
+    faer INTERNAL metadata exists (the prompt that produced it, the model, the
+    context). The gateway echo of the same message is captured separately by
+    record_message; the two views link offline by message id."""
+    if not is_enabled():
+        return
+    try:
+        record(
+            "faebot_message",
+            {
+                "message_id": getattr(sent_message, "id", None),
+                "channel": serialize_channel(getattr(sent_message, "channel", None)),
+                "content": getattr(sent_message, "content", None),
+                "conversation_id": conversation_id,
+                "prompt": prompt,
+                "model": model,
+                "context": context,
+            },
+        )
+    except Exception as error:
+        logging.debug(
+            "capture faebot_message failed: %s: %s", type(error).__name__, error
+        )
+
+
+def record_socket_raw(frame: Any) -> None:
+    """Catch-all: every gateway dispatch frame discord.py receives (needs the
+    client's enable_debug_events). Guarantees nothing we didn't anticipate slips
+    past — event types with no handler above still land here, verbatim. Skips
+    non-dispatch protocol frames (heartbeats etc., op != 0) — the PING/PONG rule."""
+    if not RAW_ENABLED or not is_enabled():
+        return
+    try:
+        if isinstance(frame, bytes):
+            return  # compressed/partial transport frames — not a dispatch event
+        parsed = json.loads(frame)
+        if parsed.get("op") != 0:
+            return  # protocol keepalive/handshake, no perceptual content
+        record("socket_raw", {"frame": parsed})
+    except Exception as error:
+        logging.debug("capture socket_raw failed: %s: %s", type(error).__name__, error)

--- a/database.py
+++ b/database.py
@@ -419,6 +419,29 @@ class FaebotDatabase:
             # Return empty dict - bot will start fresh but won't crash
             return {}
 
+    @with_retry()
+    async def save_captured_event(self, kind: str, captured_at, payload_json: str):
+        """Append one raw event to captured_events (the spike-01 capture tap).
+
+        Append-only, never updated; capture.py swallows any failure so this can
+        never disturb the bot. payload_json is already-serialized JSON.
+        """
+        if not self.pool:
+            logging.debug("No database pool - cannot save captured event")
+            return False
+
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO captured_events (captured_at, kind, payload)
+                VALUES ($1, $2, $3::jsonb)
+                """,
+                captured_at,
+                kind,
+                payload_json,
+            )
+            return True
+
     async def update_reactions(self, message_id: str, reactions: Dict[str, int]):
         """Update reactions on a bot message (for future use)"""
         if not self.pool:

--- a/faediscord.py
+++ b/faediscord.py
@@ -11,6 +11,7 @@ import discord
 import aiohttp
 from database import FaebotDatabase
 from admin_commands import admin_commands
+import capture
 import time
 
 
@@ -89,6 +90,10 @@ class Faebot(discord.Client):
         self.debug_prompts = env == "dev"  # Store debug state in the bot instance
         self.fdb = FaebotDatabase()
 
+        # Spike-01 capture tap: raw-event recording to captured_events, opt-in
+        # via SPIKE_CAPTURE. Capture-only — nothing it records feeds the prompt.
+        capture.init(self.fdb)
+
         # Add queue for handling concurrent requests
         self.pending_responses: Dict[str, asyncio.Task] = {}
         self.session: Optional[aiohttp.ClientSession] = None
@@ -101,7 +106,9 @@ class Faebot(discord.Client):
         self.proxy_recent: Dict[str, discord.Message] = {}
         self.recent_messages: Dict[str, List[Tuple[int, str, float]]] = {}
 
-        super().__init__(intents=intents)
+        # enable_debug_events lets the capture tap see raw gateway frames
+        # (on_socket_raw_receive); harmless no-op when capture is off.
+        super().__init__(intents=intents, enable_debug_events=capture.RAW_ENABLED)
 
     def _render_prompt(self, template_name, message, conversation_id):
         """Render a prompt template with live context from the message."""
@@ -243,7 +250,43 @@ class Faebot(discord.Client):
         self.conversations = await self.fdb.load_conversations()
 
         logging.info(f"Logged in as {self.user} (ID: {self.user.id})")
+        # Loud capture status so a preflight glance at the logs settles it
+        # (the SPIKE_CAPTURE_DIR silent-no-op lesson from the Twitch tap).
+        if capture.is_enabled():
+            logging.info("🎥 CAPTURE ON — recording raw events to captured_events")
+        else:
+            logging.info("capture off (SPIKE_CAPTURE not set)")
         logging.info("------")
+
+    # --- spike-01 capture delegates -------------------------------------------
+    # Thin pass-throughs to capture.py: record raw surface events for offline
+    # transduction. Capture-only — none of this feeds the live bot's prompt.
+
+    async def on_raw_message_edit(self, payload):
+        capture.record_message_edit(payload)
+
+    async def on_raw_message_delete(self, payload):
+        capture.record_message_delete(payload)
+
+    async def on_raw_reaction_add(self, payload):
+        capture.record_reaction(payload, "reaction_add")
+
+    async def on_raw_reaction_remove(self, payload):
+        capture.record_reaction(payload, "reaction_remove")
+
+    async def on_typing(self, channel, user, when):
+        capture.record_typing(channel, user, when)
+
+    async def on_member_join(self, member):
+        capture.record_member(member, "member_join")
+
+    async def on_member_remove(self, member):
+        capture.record_member(member, "member_remove")
+
+    async def on_socket_raw_receive(self, frame):
+        capture.record_socket_raw(frame)
+
+    # ---------------------------------------------------------------------------
 
     async def _handle_proxy_message(self, message, conversation_id):
         """Handle a webhook-proxied message (PluralKit, Tupperbox, etc.).
@@ -335,6 +378,10 @@ class Faebot(discord.Client):
 
     async def on_message(self, message):
         """Handles what happens when the bot receives a message"""
+        # Capture tap FIRST — before the self-check and all filtering, so the
+        # raw log keeps faebot's own echo, proxy webhooks, and dotted messages.
+        capture.record_message(message)
+
         # don't respond to ourselves
         if message.author == self.user:
             return
@@ -582,6 +629,18 @@ class Faebot(discord.Client):
 
             # Get last 5 messages as context (excluding the bot's new reply)
             context = self.conversations[conversation_id]["conversation"][-6:-1]
+
+            # Capture faer own reply WITH internal metadata (prompt/model/context)
+            # — the send point is the only place this view exists; the gateway
+            # echo of the same message is captured separately in on_message.
+            capture.record_faebot_message(
+                sent_message,
+                conversation_id=conversation_id,
+                prompt=prompt,
+                model=self.conversations[conversation_id]["model"],
+                context=context,
+            )
+
             if not await self.fdb.save_bot_message(
                 conversation_id=conversation_id,
                 content=reply,
@@ -844,6 +903,9 @@ class Faebot(discord.Client):
 # intents for the discordbot
 intents = discord.Intents.default()
 intents.message_content = True
+# members (privileged; already enabled in the dev portal) lets the capture tap
+# record member join/leave — the live bot itself doesn't use member events.
+intents.members = True
 
 # instantiate and run the bot
 if __name__ == "__main__":

--- a/migrations/004_captured_events.py
+++ b/migrations/004_captured_events.py
@@ -1,0 +1,72 @@
+"""004 — captured_events table for the spike-01 capture tap.
+
+An append-only raw event log (see capture.py): every Discord surface event the
+live bot witnesses, stored verbatim as JSONB for offline transduction into
+faebot-core Observations. The BIGSERIAL id is the watermark the offline pull
+script (faebot-private/snippets/discord/pull_captures.py) pages through.
+
+Idempotent — safe to re-run; reports state before/after.
+"""
+
+import asyncio
+import asyncpg
+import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+async def migrate():
+    database_url = os.getenv("DATABASE_URL")
+    if "localhost:5432" in database_url:
+        database_url += (
+            "?sslmode=disable" if "?" not in database_url else "&sslmode=disable"
+        )
+
+    logging.info("Connecting to database...")
+    conn = await asyncpg.connect(database_url)
+
+    try:
+        exists = await conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_name = 'captured_events'
+            )
+            """
+        )
+        if exists:
+            count = await conn.fetchval("SELECT COUNT(*) FROM captured_events")
+            logging.info(
+                f"captured_events already exists with {count} rows — nothing to migrate"
+            )
+        else:
+            logging.info("captured_events does not exist yet — creating")
+
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS captured_events (
+                id          BIGSERIAL PRIMARY KEY,
+                captured_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                kind        TEXT NOT NULL,
+                payload     JSONB NOT NULL
+            )
+            """
+        )
+        logging.info("✅ captured_events table ready")
+
+        # kind is the cheap filter axis (e.g. skip typing/socket_raw when pulling)
+        await conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_captured_events_kind
+            ON captured_events (kind)
+            """
+        )
+        logging.info("✅ kind index ready")
+
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(migrate())

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -5,6 +5,7 @@ Run migrations **in order** on a fresh database:
 - `001_initial_schema.py` — Creates initial tables (conversations, messages, participants, user profiles)
 - `002_simplify_schema_and_reactions.py` — Replaces the schema with the simplified one faebot uses today (conversations with JSONB metadata/history, plus a `bot_messages` table for reaction tracking)
 - `003_conversants_list_to_dict.py` — Converts the `conversants` field from list to dict format (no-op on a fresh database)
+- `004_captured_events.py` — Creates the append-only `captured_events` raw event log for the spike-01 capture tap (see `capture.py`; no-op if it already exists)
 
 To run each:
 
@@ -12,6 +13,7 @@ To run each:
 poetry run python migrations/001_initial_schema.py
 poetry run python migrations/002_simplify_schema_and_reactions.py
 poetry run python migrations/003_conversants_list_to_dict.py
+poetry run python migrations/004_captured_events.py
 ```
 
 > **Note:** `001` must run before `002` even though `002` rebuilds the schema — `002` performs a safety check (`SELECT COUNT(*) FROM conversations`) before dropping tables, which requires the `conversations` table created by `001` to exist.


### PR DESCRIPTION
## What

The spike-01 **in-process capture tap**: faebot now records every raw Discord surface event to an append-only `captured_events` Postgres table, for offline transduction into faebot-core `Observation`s. Sibling of faebot-twitch's `spike/01-twitch-capture` — both priority adapters now converge on the same in-process tap shape.

**Capture-only:** nothing recorded here feeds the prompt the live bot sends to its model. This is corpus accumulation for the memory spikes, not cognition.

## How

- **`capture.py`** — thin, faithful, opt-in (`SPIKE_CAPTURE`), maximalist recorder. Serializers lifted from the proven standalone spike01_listener; writes are fire-and-forget background tasks that never raise and never delay the reply path. `SPIKE_CAPTURE_RAW=0` separately kills just the raw catch-all.
- **`migrations/004_captured_events.py`** — append-only table: `BIGSERIAL id` (the pull watermark), `captured_at`, `kind`, `payload JSONB`. Idempotent + diagnostic.
- **Wiring in `faediscord.py`:**
  - message tap at the very top of `on_message` (before the self-check/filters) — keeps faebot's own echo, proxy webhooks, and dotted messages
  - raw edit/delete, raw reaction add/remove, typing, member join/remove delegates
  - `on_socket_raw_receive` catch-all (`enable_debug_events`) — gateway events we never coded for still land verbatim (op≠0 keepalives skipped)
  - send-point capture of generated replies **with internal metadata** (prompt/model/context) — the view no echo carries; links to the echo by message id
  - loud `🎥 CAPTURE ON` / `capture off` announcement in `on_ready`

The offline half (incremental watermark pull → listener-shaped JSONL) lives in faebot-private (`snippets/discord/pull_captures.py`).

## Verification

- 62 tests pass; flake8/mypy clean; capture-off is a true no-op (verified incl. garbage input, no event loop)
- Local brownie-dev test: all event kinds landed; send-point↔echo pairing 5/5 by message id; PluralKit churn fully witnessed (7 webhook reposts, 8 deleted originals captured pre-deletion, proxy tags intact); catch-all caught 3 event types we never coded (GUILD_CREATE, GUILD_MEMBERS_CHUNK, READY)
- **Deployed to prod from this branch 2026-07-01** with `SPIKE_CAPTURE=1`; live rows verified via the pull script

## Merge criteria

Draft until the overnight prod capture is verified and faebot's normal behaviour is confirmed undisturbed. Merging then matters: until this lands on main, a main deploy would silently revert capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqF23Rwxbub12BKG5btbGD
