### PR TITLE
Capture graduates: default-on with kill switch; retire bot_messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,4 @@ COPY --from=libbuilder /app/venv/lib/python3.13/site-packages /app/
 # Copy application code
 COPY . /app/
 
-WORKDIR /app
 CMD ["/usr/bin/python3.13", "/app/faediscord.py"]

--- a/capture.py
+++ b/capture.py
@@ -1,6 +1,6 @@
-"""Spike 01 (faebot-core) — Discord capture tap.
+"""Discord capture tap (born in faebot-core spike 01; graduated 2026-07-06).
 
-A *thin, faithful, opt-in, maximalist* recorder that appends raw Discord events
+A *thin, faithful, default-on, maximalist* recorder that appends raw Discord events
 to the `captured_events` Postgres table so we can transduce them into faebot-core
 `Observation`s offline (in faebot-private/snippets/discord/). It is the sibling of
 faebot-twitch's capture tap and the in-process successor to the standalone
@@ -8,10 +8,12 @@ spike01_listener: record everything the surface gives us, reason about none of i
 here — reconciliation is faebot's cognition, not the adapter's.
 
 Design rules (load-bearing — this runs inside the LIVE bot on fly):
-  * **Opt-in.** Capture happens only when SPIKE_CAPTURE is set (any non-empty
-    value). Unset = every function is a no-op, so the live bot is completely
-    unaffected unless we deliberately turn it on. SPIKE_CAPTURE_RAW=0 additionally
-    disables the raw gateway-frame catch-all if its volume gets silly.
+  * **Default-on, kill-switchable.** Capture is how faebot perceives — it runs
+    unless CAPTURE_DISABLED is set truthy ("1"/"true"/"yes"), the redeploy-free
+    kill switch if it ever misbehaves. ""/"0"/"false"/"no"/unset all mean
+    capture ON (so a documented default in fly.toml can't foot-gun).
+    CAPTURE_RAW=0 additionally disables just the raw gateway-frame catch-all
+    if its volume gets silly.
   * **Never breaks the bot.** Every extraction + write is wrapped; failures are
     swallowed and logged at debug. Writes are fired as background tasks so a slow
     or dormant database can never delay faebot's reply path.
@@ -35,8 +37,9 @@ import os
 from typing import Any, Dict, Optional
 
 
-CAPTURE_ENABLED = bool(os.getenv("SPIKE_CAPTURE", ""))
-RAW_ENABLED = CAPTURE_ENABLED and os.getenv("SPIKE_CAPTURE_RAW", "1") != "0"
+# Default-on: only an explicitly truthy CAPTURE_DISABLED turns capture off.
+CAPTURE_ENABLED = os.getenv("CAPTURE_DISABLED", "").strip().lower() in ("", "0", "false", "no")
+RAW_ENABLED = CAPTURE_ENABLED and os.getenv("CAPTURE_RAW", "1") != "0"
 
 # The database handle is injected at startup (see init) to avoid a circular import.
 _database: Optional[Any] = None

--- a/database.py
+++ b/database.py
@@ -3,7 +3,7 @@ import asyncio
 import os
 import logging
 import json
-from typing import Dict, List, Optional, Any
+from typing import Dict, Optional, Any
 from functools import wraps
 
 env = os.getenv("ENVIRONMENT", "dev").lower()
@@ -293,44 +293,6 @@ class FaebotDatabase:
             raise
 
     @with_retry()
-    async def save_bot_message(
-        self,
-        conversation_id: str,
-        content: str,
-        context: List[str],
-        message_id: Optional[str] = None,
-    ):
-        """Save a bot message with its context"""
-        if not self.pool:
-            logging.warning("No database pool - cannot save bot message")
-            return False
-
-        try:
-            async with self.pool.acquire() as conn:
-                await conn.execute(
-                    """
-                    INSERT INTO bot_messages (
-                        conversation_id, message_id, content, context
-                    ) VALUES ($1, $2, $3, $4)
-                    """,
-                    conversation_id,
-                    message_id,
-                    content,
-                    json.dumps(context),
-                )
-                logging.info(
-                    f"✅ Saved bot message to database: {conversation_id} - {content[:50]}..."
-                )
-                return True
-
-        except (TypeError, ValueError) as e:  # JSON encoding errors
-            logging.error(f"Failed to encode context as JSON: {e}")
-            return False
-        except Exception as e:
-            logging.error(f"Failed to save bot message for {conversation_id}: {e}")
-            raise
-
-    @with_retry()
     async def load_conversations(self) -> Dict[str, Dict[str, Any]]:
         """Load all conversations from the database"""
         if not self.pool:
@@ -441,19 +403,3 @@ class FaebotDatabase:
                 payload_json,
             )
             return True
-
-    async def update_reactions(self, message_id: str, reactions: Dict[str, int]):
-        """Update reactions on a bot message (for future use)"""
-        if not self.pool:
-            return
-
-        async with self.pool.acquire() as conn:
-            await conn.execute(
-                """
-                UPDATE bot_messages
-                SET reactions = $1
-                WHERE message_id = $2
-            """,
-                json.dumps(reactions),
-                message_id,
-            )

--- a/faediscord.py
+++ b/faediscord.py
@@ -90,8 +90,9 @@ class Faebot(discord.Client):
         self.debug_prompts = env == "dev"  # Store debug state in the bot instance
         self.fdb = FaebotDatabase()
 
-        # Spike-01 capture tap: raw-event recording to captured_events, opt-in
-        # via SPIKE_CAPTURE. Capture-only — nothing it records feeds the prompt.
+        # Capture tap: raw-event recording to captured_events, default-on
+        # (CAPTURE_DISABLED is the kill switch). Capture-only — nothing it
+        # records feeds the prompt.
         capture.init(self.fdb)
 
         # Add queue for handling concurrent requests
@@ -251,11 +252,11 @@ class Faebot(discord.Client):
 
         logging.info(f"Logged in as {self.user} (ID: {self.user.id})")
         # Loud capture status so a preflight glance at the logs settles it
-        # (the SPIKE_CAPTURE_DIR silent-no-op lesson from the Twitch tap).
+        # (the silent-no-op lesson from the Twitch tap).
         if capture.is_enabled():
             logging.info("🎥 CAPTURE ON — recording raw events to captured_events")
         else:
-            logging.info("capture off (SPIKE_CAPTURE not set)")
+            logging.warning("⚠️ capture OFF (CAPTURE_DISABLED is set — faebot is not recording)")
         logging.info("------")
 
     # --- spike-01 capture delegates -------------------------------------------
@@ -641,15 +642,7 @@ class Faebot(discord.Client):
                 context=context,
             )
 
-            if not await self.fdb.save_bot_message(
-                conversation_id=conversation_id,
-                content=reply,
-                context=context,
-                message_id=str(sent_message.id) if sent_message else None,
-            ):
-                logging.warning(f"Failed to save bot message for {conversation_id}")
-
-            # Also save the updated conversation state
+            # Save the updated conversation state
             if not await self.fdb.save_conversation(
                 conversation_id, self.conversations[conversation_id]
             ):

--- a/fly.toml
+++ b/fly.toml
@@ -17,28 +17,7 @@ processes = []
 [experimental]
   auto_rollback = true
 
-[[services]]
-  http_checks = []
-  internal_port = 8080
-  processes = ["app"]
-  protocol = "tcp"
-  script_checks = []
-  [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
-    type = "connections"
-
-  [[services.ports]]
-    force_https = true
-    handlers = ["http"]
-    port = 80
-
-  [[services.ports]]
-    handlers = ["tls", "http"]
-    port = 443
-
-  [[services.tcp_checks]]
-    grace_period = "1s"
-    interval = "15s"
-    restart_limit = 0
-    timeout = "2s"
+# No [[services]] block on purpose: faebot is a Discord client, all-outbound.
+# The 2023-era block declared ports 80/443 and a TCP health check on 8080
+# where nothing ever listened — every deploy stalled on a check that could
+# never pass. Removed 2026-07-06 (PR #28).

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,10 @@ processes = []
 [env]
   ENVIRONMENT = "prod"
   USE_LOCAL_MODEL = "false"
+  # Capture is default-on (how faebot perceives). Set truthy ("1"/"true") to
+  # kill raw-event recording without a code change; CAPTURE_RAW = "0" would
+  # disable just the gateway-frame catch-all. See capture.py.
+  CAPTURE_DISABLED = "false"
 
 
 [experimental]

--- a/fly.toml
+++ b/fly.toml
@@ -8,10 +8,12 @@ processes = []
 [env]
   ENVIRONMENT = "prod"
   USE_LOCAL_MODEL = "false"
-  # Capture is default-on (how faebot perceives). Set truthy ("1"/"true") to
-  # kill raw-event recording without a code change; CAPTURE_RAW = "0" would
-  # disable just the gateway-frame catch-all. See capture.py.
+  # Capture dials (see capture.py) — documented here at their defaults so the
+  # config is a complete map of what can be turned. CAPTURE_DISABLED set
+  # truthy ("1"/"true") kills all raw-event recording without a code change;
+  # CAPTURE_RAW = "0" disables just the gateway-frame catch-all.
   CAPTURE_DISABLED = "false"
+  CAPTURE_RAW = "1"
 
 
 [experimental]

--- a/migrations/005_drop_bot_messages.py
+++ b/migrations/005_drop_bot_messages.py
@@ -33,6 +33,12 @@ async def migrate():
     conn = await asyncpg.connect(database_url)
 
     try:
+        # Announce the target BEFORE acting — DATABASE_URL is trusted blindly,
+        # and a mis-sourced environment once pointed a migration at the wrong
+        # database (2026-07-06). Make the blast zone legible.
+        target = await conn.fetchrow("SELECT current_user AS usr, current_database() AS db")
+        logging.info(f"Target: {target['usr']} @ {target['db']}")
+
         exists = await conn.fetchval(
             """
             SELECT EXISTS (

--- a/migrations/005_drop_bot_messages.py
+++ b/migrations/005_drop_bot_messages.py
@@ -1,0 +1,57 @@
+"""005 — drop the bot_messages table (superseded by captured_events).
+
+bot_messages stored each bot post with the context that fed its prompt — send-
+point provenance. Since the capture tap (004 + PR #26), captured_events records
+the same send point with MORE metadata (prompt, model, context) as
+kind='faebot_message', plus the gateway echo — so bot_messages is a legacy
+organ. Its planned reactions feature was never used and reaction provenance
+now lives in captured_events too (reaction_add / reaction_remove events).
+
+Verdict: fae, 2026-07-06 — "completely superseded; can go today."
+Take a backup dump BEFORE running this (backup_db.py); the dropped rows
+remain recoverable from any prior dump forever.
+
+Idempotent — safe to re-run; reports state before/after.
+"""
+
+import asyncio
+import asyncpg
+import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+async def migrate():
+    database_url = os.getenv("DATABASE_URL")
+    if "localhost:5432" in database_url:
+        database_url += (
+            "?sslmode=disable" if "?" not in database_url else "&sslmode=disable"
+        )
+
+    logging.info("Connecting to database...")
+    conn = await asyncpg.connect(database_url)
+
+    try:
+        exists = await conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_name = 'bot_messages'
+            )
+            """
+        )
+        if exists:
+            count = await conn.fetchval("SELECT COUNT(*) FROM bot_messages")
+            logging.info(f"bot_messages exists with {count} rows — dropping")
+            await conn.execute("DROP TABLE bot_messages")
+            logging.info(f"✅ bot_messages dropped ({count} rows retired; recoverable from dumps)")
+        else:
+            logging.info("bot_messages does not exist — nothing to migrate")
+
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(migrate())

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -5,7 +5,8 @@ Run migrations **in order** on a fresh database:
 - `001_initial_schema.py` — Creates initial tables (conversations, messages, participants, user profiles)
 - `002_simplify_schema_and_reactions.py` — Replaces the schema with the simplified one faebot uses today (conversations with JSONB metadata/history, plus a `bot_messages` table for reaction tracking)
 - `003_conversants_list_to_dict.py` — Converts the `conversants` field from list to dict format (no-op on a fresh database)
-- `004_captured_events.py` — Creates the append-only `captured_events` raw event log for the spike-01 capture tap (see `capture.py`; no-op if it already exists)
+- `004_captured_events.py` — Creates the append-only `captured_events` raw event log for the capture tap (see `capture.py`; no-op if it already exists)
+- `005_drop_bot_messages.py` — Drops the `bot_messages` table (superseded by `captured_events`; take a backup dump first — no-op once dropped)
 
 To run each:
 
@@ -14,6 +15,7 @@ poetry run python migrations/001_initial_schema.py
 poetry run python migrations/002_simplify_schema_and_reactions.py
 poetry run python migrations/003_conversants_list_to_dict.py
 poetry run python migrations/004_captured_events.py
+poetry run python migrations/005_drop_bot_messages.py
 ```
 
 > **Note:** `001` must run before `002` even though `002` rebuilds the schema — `002` performs a safety check (`SELECT COUNT(*) FROM conversations`) before dropping tables, which requires the `conversations` table created by `001` to exist.

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -26,7 +26,6 @@ class TestFaebot:
             # Mock the database to avoid actual database calls
             bot.fdb = Mock()
             bot.fdb.save_conversation = AsyncMock(return_value=True)
-            bot.fdb.save_bot_message = AsyncMock(return_value=True)
             bot.fdb.get_conversation = AsyncMock(return_value=None)
             bot.fdb.connect = AsyncMock(return_value=True)
             bot.fdb.close = AsyncMock(return_value=True)


### PR DESCRIPTION
## Capture graduates: default-on + retire bot_messages

Two paired moves from the see-and-edit story's chore queue (design record: faebot-private `notes/discord-status.md`):

### 1. Capture is no longer an experiment
- `SPIKE_CAPTURE` (opt-in) → **`CAPTURE_DISABLED`** (default-on kill switch). Capture is how faebot perceives; the flag now only exists to turn it *off* in an emergency, redeploy-free.
- Truthy-parsed: `""`/`"0"`/`"false"`/`"no"`/unset all mean capture **ON** — so the documented `CAPTURE_DISABLED = "false"` default in fly.toml can't foot-gun.
- Raw catch-all dial renamed `SPIKE_CAPTURE_RAW` → `CAPTURE_RAW` (nothing sets it anywhere; free rename).
- on_ready's capture-OFF branch is now a loud **warning** — off means faebot isn't recording.

### 2. bot_messages retired
Completely superseded by `captured_events`: the capture tap records the send point with **more** metadata (prompt/model/context, as `kind='faebot_message'`) plus the gateway echo. The planned reactions feature was never used; reaction provenance lives in `captured_events` too.
- `save_bot_message` + `update_reactions` removed; the write per reply is gone.
- **Migration 005** drops the table — idempotent, reports row counts, no-op on re-run.

### Deploy order (matters!)
1. Backup dump (`backup_db.py` — fingerprinted; dropped rows stay recoverable forever)
2. Deploy this branch (stops the `bot_messages` writes)
3. Verify logs: `🎥 CAPTURE ON` with no SPIKE_CAPTURE set
4. `fly secrets unset SPIKE_CAPTURE`
5. Run migration 005 over the proxy
6. `pgprobe --fly` → two tables

Also carries the duplicate-`WORKDIR` Dockerfile cleanup (no-op artifact PR #27 missed).

Tests: 62 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
