### PR TITLE
Settings split: per-channel dials become data (+ env guard, kimi fix)

### DIFF
--- a/admin_commands.py
+++ b/admin_commands.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from decimal import Decimal
 from functools import wraps
 
 # Get environment variables
@@ -201,7 +202,11 @@ async def _set_reply_frequency(bot, message, message_tokens, conversation_id):
                 return await message.channel.send("Frequency must be between 0 and 1")
             old_freq = bot.conversations[target_id]["reply_frequency"]
             bot.conversations[target_id]["reply_frequency"] = new_freq
-            await bot.fdb.set_channel_setting(target_id, "reply_frequency", new_freq)
+            # Store the exact decimal (from the original string) so the NUMERIC
+            # column keeps 0.3 as 0.3, not the 0.29999… float approximation.
+            await bot.fdb.set_channel_setting(
+                target_id, "reply_frequency", Decimal(message_tokens[1])
+            )
             logging.debug(
                 f"Admin {message.author.name} changed reply frequency for conversation {target_id} from {old_freq} to {new_freq}"
             )

--- a/admin_commands.py
+++ b/admin_commands.py
@@ -165,6 +165,7 @@ async def _set_or_return_model(bot, message, message_tokens=None, conversation_i
         new_model = message_tokens[1]
         old_model = bot.conversations[target_id]["model"]
         bot.conversations[target_id]["model"] = new_model
+        await bot.fdb.set_channel_setting(target_id, "model", new_model)
         logging.debug(
             f"Admin {message.author.name} changed model for conversation {target_id} from {old_model} to {new_model}"
         )
@@ -200,6 +201,7 @@ async def _set_reply_frequency(bot, message, message_tokens, conversation_id):
                 return await message.channel.send("Frequency must be between 0 and 1")
             old_freq = bot.conversations[target_id]["reply_frequency"]
             bot.conversations[target_id]["reply_frequency"] = new_freq
+            await bot.fdb.set_channel_setting(target_id, "reply_frequency", new_freq)
             logging.debug(
                 f"Admin {message.author.name} changed reply frequency for conversation {target_id} from {old_freq} to {new_freq}"
             )
@@ -239,11 +241,14 @@ async def _set_history_length(bot, message, message_tokens, conversation_id):
 
     if len(message_tokens) > length_index:
         try:
-            new_length = int(message_tokens[1])
+            # length_index skips the optional conversation-id token — reading
+            # message_tokens[1] here was the snowflake-as-length corruption bug.
+            new_length = int(message_tokens[length_index])
             if new_length < 1:
                 return await message.channel.send("History length must be positive")
             old_length = bot.conversations[target_id]["history_length"]
             bot.conversations[target_id]["history_length"] = new_length
+            await bot.fdb.set_channel_setting(target_id, "history_length", new_length)
             logging.debug(
                 f"Admin {message.author.name} changed history length for conversation {target_id} from {old_length} to {new_length}"
             )

--- a/database.py
+++ b/database.py
@@ -355,6 +355,31 @@ class FaebotDatabase:
             # Return empty dict - bot will start fresh but won't crash
             return {}
 
+    async def assert_environment(self, expected: str):
+        """Refuse to run against a database stamped for a different environment.
+
+        The startup half of the meta guard (migration 007). Graceful during
+        rollout: a database without the meta table (pre-007) only warns, so
+        nothing breaks before 007 has run everywhere.
+        """
+        if not self.pool:
+            logging.warning("No database pool — cannot verify environment")
+            return
+        async with self.pool.acquire() as conn:
+            has_meta = await conn.fetchval("SELECT to_regclass('public.meta')")
+            if not has_meta:
+                logging.warning(
+                    "meta table absent — cannot verify environment (run migration 007)"
+                )
+                return
+            stamped = await conn.fetchval("SELECT environment FROM meta WHERE id = 1")
+        if stamped != expected:
+            raise RuntimeError(
+                f"❌ ENVIRONMENT MISMATCH: database is stamped '{stamped}' but the bot's "
+                f"ENVIRONMENT is '{expected}'. Refusing to start — wrong database?"
+            )
+        logging.info(f"✅ Environment verified: connected database is '{expected}'")
+
     @with_retry()
     async def get_effective_settings(
         self, conversation_id: str, is_dm: bool = False

--- a/database.py
+++ b/database.py
@@ -215,9 +215,16 @@ class FaebotDatabase:
         self,
         conversation_id: str,
         conversation_data: Dict[str, Any],
-        force_overwrite: bool = False,
     ):
-        """Save or update a conversation's full state"""
+        """Save a conversation's identity + history.
+
+        The metadata blob now holds only identity (name, conversants) — the
+        four dials live in channel_settings (the settings split), so this write
+        never touches them. The old shrink-guard is gone with them: history
+        trimming and fae;forget are legitimate, so a shorter history is saved
+        faithfully by the plain upsert. (Single-instance bot — no concurrent
+        writer to guard against; revisit if that ever changes.)
+        """
         if not self.pool:
             logging.warning("No database pool - cannot save conversation")
             return False
@@ -226,66 +233,11 @@ class FaebotDatabase:
             metadata = {
                 "id": conversation_data["id"],
                 "name": conversation_data["name"],
-                "history_length": conversation_data["history_length"],
-                "reply_frequency": conversation_data["reply_frequency"],
-                "prompt_template": conversation_data.get(
-                    "prompt_template", DEFAULT_TEMPLATE
-                ),
-                "model": conversation_data["model"],
                 "conversants": conversation_data.get("conversants", {}),
             }
-
             history = conversation_data.get("conversation", [])
 
             async with self.pool.acquire() as conn:
-                # Check if conversation exists
-                existing = await conn.fetchrow(
-                    """
-                    SELECT
-                        jsonb_array_length(conversation_history) as len,
-                        conversation_history->-1 as last_message  -- Get last message
-                    FROM conversations
-                    WHERE id = $1
-                    """,
-                    conversation_id,
-                )
-
-                if existing and not force_overwrite:
-                    existing_len = existing["len"]
-
-                    # Check if we're potentially losing messages
-                    if existing_len > len(history):
-                        # Try to detect if this is a legitimate trim vs data loss
-                        last_db_message = (
-                            json.loads(existing["last_message"])
-                            if existing["last_message"]
-                            else None
-                        )
-
-                        # Check if our history contains the last DB message
-                        if last_db_message and last_db_message not in history:
-                            logging.warning(
-                                f"⚠️ Refusing to save {conversation_id}: "
-                                f"DB has {existing_len} messages, memory has {len(history)}, "
-                                f"and memory doesn't contain last DB message. "
-                                f"This might lose data!"
-                            )
-                            # Just update metadata
-                            await conn.execute(
-                                """
-                                UPDATE conversations
-                                SET conversation_metadata = $1, last_updated = CURRENT_TIMESTAMP
-                                WHERE id = $2
-                                """,
-                                json.dumps(metadata),
-                                conversation_id,
-                            )
-                            logging.info(
-                                f"Updated metadata only for conversation {conversation_id}"
-                            )
-                            return True
-
-                # Normal save
                 await conn.execute(
                     """
                     INSERT INTO conversations (
@@ -301,13 +253,11 @@ class FaebotDatabase:
                     json.dumps(metadata),
                     json.dumps(history),
                 )
-
-                action = "Created" if not existing else "Updated"
-                logging.info(
-                    f"✅ {action} conversation {conversation_data['name']} "
-                    f"with {len(history)} messages in database"
-                )
-                return True
+            logging.info(
+                f"✅ Saved conversation {conversation_data['name']} "
+                f"with {len(history)} messages"
+            )
+            return True
 
         except (TypeError, ValueError) as e:  # JSON encoding errors
             logging.error(f"Failed to encode conversation data as JSON: {e}")

--- a/database.py
+++ b/database.py
@@ -91,7 +91,12 @@ def with_retry(max_retries=3, initial_delay=1, backoff_factor=2):
 class FaebotDatabase:
     def __init__(self):
         self.pool: Optional[asyncpg.Pool] = None
-        self.database_url = os.getenv("DATABASE_URL", "")
+        # The environment picks WHICH variable to read (the stale-shell
+        # disarm, 2026-07-07): prod reads DATABASE_URL as fly injects it;
+        # dev reads DEV_DATABASE_URL, so a shell polluted with prod secrets
+        # cannot silently hand the dev bot the production database.
+        url_variable = "DATABASE_URL" if env == "prod" else "DEV_DATABASE_URL"
+        self.database_url = os.getenv(url_variable, "")
 
         # Add sslmode=disable for local proxy
         if self.database_url and "localhost:5432" in self.database_url:

--- a/database.py
+++ b/database.py
@@ -9,6 +9,25 @@ from functools import wraps
 env = os.getenv("ENVIRONMENT", "dev").lower()
 DEFAULT_TEMPLATE = "dev" if env == "dev" else "default"
 
+# The four per-channel dials, now sourced from the channel_settings table
+# (the settings split). Whitelist — set_channel_setting refuses anything else,
+# so the column name can be safely interpolated into SQL.
+SETTINGS_COLUMNS = ("model", "reply_frequency", "history_length", "prompt_template")
+
+# Special rows in channel_settings: policy defaults, not conversations.
+DEFAULT_ROW = "__default__"
+DEFAULT_DM_ROW = "__default_dm__"
+
+# Last-resort floor if channel_settings has no usable value at all (e.g. the
+# __default__ row is somehow missing). Never-break-the-bot; a use is logged
+# loudly because it means the defaults row needs fixing.
+SETTINGS_EMERGENCY_DEFAULTS = {
+    "model": "moonshotai/kimi-k2",
+    "reply_frequency": 0.05,
+    "history_length": 69,
+    "prompt_template": "default",
+}
+
 
 def with_retry(max_retries=3, initial_delay=1, backoff_factor=2):
     """Decorator for database operations with retry logic for dormant connections"""
@@ -385,6 +404,87 @@ class FaebotDatabase:
             )
             # Return empty dict - bot will start fresh but won't crash
             return {}
+
+    @with_retry()
+    async def get_effective_settings(
+        self, conversation_id: str, is_dm: bool = False
+    ) -> Dict[str, Any]:
+        """Resolve a channel's effective settings via NULL-inheritance.
+
+        Precedence (first non-NULL wins per field):
+            guild: own row -> __default__
+            dm:    own row -> __default_dm__ -> __default__
+        Falls back to SETTINGS_EMERGENCY_DEFAULTS (loudly) if even the default
+        row can't supply a value.
+        """
+        if not self.pool:
+            logging.warning(
+                "No database pool — serving emergency default settings for %s",
+                conversation_id,
+            )
+            return dict(SETTINGS_EMERGENCY_DEFAULTS)
+
+        wanted_ids = [conversation_id]
+        if is_dm:
+            wanted_ids.append(DEFAULT_DM_ROW)
+        wanted_ids.append(DEFAULT_ROW)
+
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT * FROM channel_settings WHERE conversation_id = ANY($1)",
+                wanted_ids,
+            )
+
+        by_id = {row["conversation_id"]: row for row in rows}
+        # Precedence order matches wanted_ids (own first, __default__ last).
+        precedence = [by_id[row_id] for row_id in wanted_ids if row_id in by_id]
+
+        resolved: Dict[str, Any] = {}
+        for column in SETTINGS_COLUMNS:
+            value = next(
+                (row[column] for row in precedence if row[column] is not None), None
+            )
+            if value is None:
+                value = SETTINGS_EMERGENCY_DEFAULTS[column]
+                logging.warning(
+                    "⚠️ No value for '%s' in channel_settings (channel %s) — "
+                    "using emergency default %r. The %s row may need fixing.",
+                    column, conversation_id, value, DEFAULT_ROW,
+                )
+            resolved[column] = value
+
+        # reply_frequency is NUMERIC -> Decimal; the bot's dice want a float.
+        resolved["reply_frequency"] = float(resolved["reply_frequency"])
+        return resolved
+
+    @with_retry()
+    async def set_channel_setting(self, conversation_id: str, key: str, value: Any):
+        """Write-through a single setting (UPSERT). NULL value = reset to inherit.
+
+        `key` is whitelisted against SETTINGS_COLUMNS, so it is safe to
+        interpolate into the SQL; values are always parameterised.
+        """
+        if key not in SETTINGS_COLUMNS:
+            raise ValueError(f"unknown setting {key!r}")
+        if not self.pool:
+            logging.warning("No database pool — cannot set %s for %s", key, conversation_id)
+            return False
+
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                f"""
+                INSERT INTO channel_settings (conversation_id, {key})
+                VALUES ($1, $2)
+                ON CONFLICT (conversation_id)
+                DO UPDATE SET {key} = EXCLUDED.{key}
+                """,
+                conversation_id,
+                value,
+            )
+        logging.info(
+            "✅ channel_settings: %s.%s = %r", conversation_id, key, value
+        )
+        return True
 
     @with_retry()
     async def save_captured_event(self, kind: str, captured_at, payload_json: str):

--- a/faediscord.py
+++ b/faediscord.py
@@ -810,6 +810,11 @@ class Faebot(discord.Client):
                     "max_tokens": 250,
                     "stop": ["[20"],
                     "frequency_penalty": 1.5,
+                    # Disable provider-side reasoning: some OpenRouter providers
+                    # (e.g. Novita for kimi-k2) run a hidden reasoning pass that
+                    # eats the whole max_tokens budget and returns empty text —
+                    # faebot goes silent. We want plain completion, no reasoning.
+                    "reasoning": {"enabled": False},
                 }
 
             async with self.session.post(

--- a/faediscord.py
+++ b/faediscord.py
@@ -263,6 +263,10 @@ class Faebot(discord.Client):
         # Initialize database connection
         await self.fdb.connect()
 
+        # Refuse to run against a database stamped for a different environment
+        # (the meta guard — catches wrong-DB no matter how the URL got here).
+        await self.fdb.assert_environment(env)
+
         # Load existing conversations from database
         self.conversations = await self.fdb.load_conversations()
 

--- a/faediscord.py
+++ b/faediscord.py
@@ -111,6 +111,22 @@ class Faebot(discord.Client):
         # (on_socket_raw_receive); harmless no-op when capture is off.
         super().__init__(intents=intents, enable_debug_events=capture.RAW_ENABLED)
 
+    async def _refresh_channel_settings(self, message, conversation_id):
+        """Pull this channel's four dials (model, reply_frequency,
+        history_length, prompt_template) from channel_settings into the
+        in-memory conversation dict.
+
+        Called once per incoming message, before any setting is read — so an
+        edit made anywhere (a fae; command, the CLI, a future slash command,
+        another process) takes effect on the very next message with no restart.
+        The dict is a per-message cache; channel_settings is the source of truth.
+        """
+        if conversation_id not in self.conversations:
+            return
+        is_dm = isinstance(message.channel, discord.DMChannel)
+        settings = await self.fdb.get_effective_settings(conversation_id, is_dm)
+        self.conversations[conversation_id].update(settings)
+
     def _render_prompt(self, template_name, message, conversation_id):
         """Render a prompt template with live context from the message."""
         template = PROMPT_TEMPLATES.get(template_name, PROMPT_TEMPLATES["default"])
@@ -404,6 +420,10 @@ class Faebot(discord.Client):
 
         # Log message if channel is known, regardless of reply status
         if conversation_id in self.conversations:
+            # Settings first: refresh from channel_settings so every downstream
+            # read (trim, respond-dice, generation) sees live-edited values.
+            await self._refresh_channel_settings(message, conversation_id)
+
             # Check if we should do a periodic save (every 10 messages or 5 minutes)
             if conversation_id in self.conversations:
                 conv_length = len(self.conversations[conversation_id]["conversation"])
@@ -512,31 +532,31 @@ class Faebot(discord.Client):
                 f"*{self.user.display_name} remembers this place*"
             )
 
-        # Determine template and frequency based on channel type
+        # Determine channel name + whether this is a DM. Settings are NOT
+        # stamped at creation anymore — a new channel inherits __default__
+        # (or __default_dm__) from channel_settings until something overrides.
         if message.channel.type[0] == "text":
-            template = DEFAULT_TEMPLATE
-            reply_frequency = 0.05
+            is_dm = False
             name = str(message.channel.name)
         elif message.channel.type[0] == "private":
-            template = "dm"
-            reply_frequency = 1
+            is_dm = True
             name = str(message.author.display_name)
         else:
             return await message.channel.send(
                 "Unknown channel type. Unable to proceed. Please contact administrator"
             )
 
-        # initialize conversation
+        # initialize conversation (name/conversants/history only)
         self.conversations[conversation_id] = {
             "id": conversation_id,
             "conversation": [],
             "conversants": {message.author.name: message.author.display_name},
-            "history_length": 20,
-            "reply_frequency": reply_frequency,
             "name": name,
-            "prompt_template": template,
-            "model": self.model,
         }
+        # Populate the four dials from channel_settings (inherited, not stamped).
+        self.conversations[conversation_id].update(
+            await self.fdb.get_effective_settings(conversation_id, is_dm)
+        )
 
         logging.info(
             f"Initialized new conversation {self.conversations[conversation_id]['name']} with ID {conversation_id}."

--- a/faediscord.py
+++ b/faediscord.py
@@ -498,6 +498,12 @@ class Faebot(discord.Client):
         message_tokens = message.content.split(" ")
         command = message_tokens[0]
 
+        # Refresh the current channel's settings so a fae; query/command sees
+        # live channel_settings values (admin commands are handled before the
+        # per-message refresh). Covers the common case of tuning the channel
+        # you're in; remote-channel queries fall back to the cached dict.
+        await self._refresh_channel_settings(message, conversation_id)
+
         if command in admin_commands:
             return await admin_commands[command](
                 self, message, message_tokens, conversation_id

--- a/faediscord.py
+++ b/faediscord.py
@@ -483,7 +483,7 @@ class Faebot(discord.Client):
 
             # Handle reply if needed
             return await self._handle_conversation(message, conversation_id)
-        elif message.channel.type[0] == "private":
+        elif isinstance(message.channel, discord.DMChannel):
             # if the conversation doesn't exist and it's a DM, create a new one
             await self._initialize_conversation(
                 message, message_tokens=None, conversation_id=conversation_id
@@ -541,10 +541,10 @@ class Faebot(discord.Client):
         # Determine channel name + whether this is a DM. Settings are NOT
         # stamped at creation anymore — a new channel inherits __default__
         # (or __default_dm__) from channel_settings until something overrides.
-        if message.channel.type[0] == "text":
+        if isinstance(message.channel, discord.TextChannel):
             is_dm = False
             name = str(message.channel.name)
-        elif message.channel.type[0] == "private":
+        elif isinstance(message.channel, discord.DMChannel):
             is_dm = True
             name = str(message.author.display_name)
         else:

--- a/migrations/006_channel_settings.py
+++ b/migrations/006_channel_settings.py
@@ -25,20 +25,44 @@ Additive and idempotent — safe before the code that reads it deploys;
 ON CONFLICT DO NOTHING so re-runs never clobber edited defaults.
 """
 
+import argparse
 import asyncio
 import asyncpg
 import os
 import logging
+import sys
 
 logging.basicConfig(level=logging.INFO)
 
 
-async def migrate():
-    database_url = os.getenv("DATABASE_URL")
+def resolve_database_url() -> str:
+    """Require an explicit --env; read the matching explicit variable.
+
+    The stale-shell disarm (2026-07-07): migrations no longer read ambient
+    DATABASE_URL — you must SAY which world you mean, and the variable name
+    matches the secrets file that provides it (dev_discord_secrets.fish /
+    prod_discord_secrets.fish). Pattern for all migrations from 006 onward.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env", required=True, choices=["dev", "prod"],
+                        help="which database this migration targets")
+    arguments = parser.parse_args()
+
+    variable = "PROD_DATABASE_URL" if arguments.env == "prod" else "DEV_DATABASE_URL"
+    database_url = os.getenv(variable, "")
+    if not database_url:
+        sys.exit(f"{variable} is not set — source ../secrets/{arguments.env}_discord_secrets.fish first")
+    logging.info(f"Requested environment: {arguments.env} (via {variable})")
+
     if "localhost:5432" in database_url:
         database_url += (
             "?sslmode=disable" if "?" not in database_url else "&sslmode=disable"
         )
+    return database_url
+
+
+async def migrate():
+    database_url = resolve_database_url()
 
     logging.info("Connecting to database...")
     conn = await asyncpg.connect(database_url)

--- a/migrations/006_channel_settings.py
+++ b/migrations/006_channel_settings.py
@@ -1,0 +1,90 @@
+"""006 — channel_settings: per-channel dials split out of the metadata blob.
+
+The settings-split (see-and-edit story): settings move from the JSONB
+metadata blob (glued to conversation history, stamped at creation, editable
+only via fragile DM commands) into a typed table the database can defend
+with CHECK constraints and any interface can read/write.
+
+Inheritance model (NULL = inherit):
+  - one row per conversation THAT OVERRIDES something (no row = all-inherit)
+  - '__default__' policy row: the defaults for guild channels
+  - '__default_dm__' policy row: what's DIFFERENT about DMs (its NULLs fall
+    through to '__default__')
+  Effective setting: guild = COALESCE(override, default)
+                     dm    = COALESCE(override, dm_default, default)
+
+The policy rows are seeded here (universal — every environment wants them);
+channel-specific overrides are environment data and are applied manually,
+NOT in this migration (they reference snowflake ids that only exist in one
+database).
+
+conversation_id matches conversations.id by convention — deliberately no
+FOREIGN KEY, because the policy rows aren't conversations.
+
+Additive and idempotent — safe before the code that reads it deploys;
+ON CONFLICT DO NOTHING so re-runs never clobber edited defaults.
+"""
+
+import asyncio
+import asyncpg
+import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+async def migrate():
+    database_url = os.getenv("DATABASE_URL")
+    if "localhost:5432" in database_url:
+        database_url += (
+            "?sslmode=disable" if "?" not in database_url else "&sslmode=disable"
+        )
+
+    logging.info("Connecting to database...")
+    conn = await asyncpg.connect(database_url)
+
+    try:
+        # Announce the target BEFORE acting (the 005 lesson).
+        target = await conn.fetchrow(
+            "SELECT current_user AS usr, current_database() AS db"
+        )
+        logging.info(f"Target: {target['usr']} @ {target['db']}")
+
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS channel_settings (
+                conversation_id TEXT PRIMARY KEY,
+                model           TEXT,
+                reply_frequency NUMERIC CHECK (reply_frequency BETWEEN 0 AND 1),
+                history_length  INT  CHECK (history_length > 0),
+                prompt_template TEXT
+            )
+            """
+        )
+        logging.info("✅ channel_settings table ready")
+
+        seeded = await conn.execute(
+            """
+            INSERT INTO channel_settings
+                (conversation_id, model, reply_frequency, history_length, prompt_template)
+            VALUES
+                ('__default__',    'moonshotai/kimi-k2', 0.05, 69,   'default'),
+                ('__default_dm__', NULL,                 1.0,  NULL, 'dm')
+            ON CONFLICT (conversation_id) DO NOTHING
+            """
+        )
+        logging.info(f"Policy rows: {seeded} (0 = already present, untouched)")
+
+        rows = await conn.fetch(
+            "SELECT * FROM channel_settings ORDER BY conversation_id"
+        )
+        for row in rows:
+            logging.info(f"  {dict(row)}")
+        logging.info(f"✅ channel_settings holds {len(rows)} row(s)")
+
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(migrate())

--- a/migrations/007_environment_meta.py
+++ b/migrations/007_environment_meta.py
@@ -1,0 +1,83 @@
+"""007 — meta table: stamp the database's environment ('dev' or 'prod').
+
+The third layer of the stale-shell disarm (see faebot-private
+notes/infrastructure.md): after this, the *database itself* knows which
+environment it is, and both the bot (at startup) and later migrations assert
+a match — so a wrong-database connection is caught no matter HOW the bad URL
+got into the environment (stale shell, pasted URL, proxy mixup, an agent
+launched from a polluted terminal).
+
+This migration is itself guarded: if the database is already stamped with a
+DIFFERENT environment than --env, it refuses (you're pointing at the wrong DB).
+
+Idempotent — safe to re-run.
+"""
+
+import argparse
+import asyncio
+import asyncpg
+import os
+import logging
+import sys
+
+logging.basicConfig(level=logging.INFO)
+
+
+def resolve() -> tuple[str, str]:
+    """Return (requested_env, database_url); require an explicit --env."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env", required=True, choices=["dev", "prod"],
+                        help="which database this migration targets + stamps")
+    arguments = parser.parse_args()
+
+    variable = "PROD_DATABASE_URL" if arguments.env == "prod" else "DEV_DATABASE_URL"
+    database_url = os.getenv(variable, "")
+    if not database_url:
+        sys.exit(f"{variable} is not set — source ../secrets/{arguments.env}_discord_secrets.fish first")
+    if "localhost:5432" in database_url:
+        database_url += (
+            "?sslmode=disable" if "?" not in database_url else "&sslmode=disable"
+        )
+    return arguments.env, database_url
+
+
+async def migrate():
+    requested_env, database_url = resolve()
+    logging.info(f"Requested environment: {requested_env}")
+
+    conn = await asyncpg.connect(database_url)
+    try:
+        target = await conn.fetchrow(
+            "SELECT current_user AS usr, current_database() AS db"
+        )
+        logging.info(f"Target: {target['usr']} @ {target['db']}")
+
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS meta (
+                id          INT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+                environment TEXT NOT NULL
+            )
+            """
+        )
+
+        stamped = await conn.fetchval("SELECT environment FROM meta WHERE id = 1")
+        if stamped is None:
+            await conn.execute(
+                "INSERT INTO meta (id, environment) VALUES (1, $1)", requested_env
+            )
+            logging.info(f"✅ Database stamped as environment '{requested_env}'")
+        elif stamped != requested_env:
+            sys.exit(
+                f"❌ MISMATCH: this database is already stamped '{stamped}', but you "
+                f"ran --env {requested_env}. Wrong database?! Refusing to change the stamp."
+            )
+        else:
+            logging.info(f"Already stamped '{stamped}' — matches, nothing to do")
+
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(migrate())

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -7,6 +7,7 @@ Run migrations **in order** on a fresh database:
 - `003_conversants_list_to_dict.py` — Converts the `conversants` field from list to dict format (no-op on a fresh database)
 - `004_captured_events.py` — Creates the append-only `captured_events` raw event log for the capture tap (see `capture.py`; no-op if it already exists)
 - `005_drop_bot_messages.py` — Drops the `bot_messages` table (superseded by `captured_events`; take a backup dump first — no-op once dropped)
+- `006_channel_settings.py` — Creates the typed `channel_settings` table (the settings-split) and seeds the `__default__` / `__default_dm__` policy rows. Channel-specific overrides are environment data — applied manually, never in the migration.
 
 To run each:
 
@@ -16,6 +17,7 @@ poetry run python migrations/002_simplify_schema_and_reactions.py
 poetry run python migrations/003_conversants_list_to_dict.py
 poetry run python migrations/004_captured_events.py
 poetry run python migrations/005_drop_bot_messages.py
+poetry run python migrations/006_channel_settings.py
 ```
 
 > **Note:** `001` must run before `002` even though `002` rebuilds the schema — `002` performs a safety check (`SELECT COUNT(*) FROM conversations`) before dropping tables, which requires the `conversations` table created by `001` to exist.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -17,8 +17,15 @@ poetry run python migrations/002_simplify_schema_and_reactions.py
 poetry run python migrations/003_conversants_list_to_dict.py
 poetry run python migrations/004_captured_events.py
 poetry run python migrations/005_drop_bot_messages.py
-poetry run python migrations/006_channel_settings.py
+poetry run python migrations/006_channel_settings.py --env dev   # or --env prod
 ```
+
+> **From 006 onward**, migrations require an explicit `--env dev|prod` flag and
+> read `DEV_DATABASE_URL` / `PROD_DATABASE_URL` (never ambient `DATABASE_URL`) —
+> the variable name matches the secrets file that provides it. They also
+> announce `current_user @ current_database` before acting. Both habits exist
+> because a stale-sourced shell once pointed a migration at the wrong database
+> (2026-07-06).
 
 > **Note:** `001` must run before `002` even though `002` rebuilds the schema — `002` performs a safety check (`SELECT COUNT(*) FROM conversations`) before dropping tables, which requires the `conversations` table created by `001` to exist.
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -8,6 +8,7 @@ Run migrations **in order** on a fresh database:
 - `004_captured_events.py` — Creates the append-only `captured_events` raw event log for the capture tap (see `capture.py`; no-op if it already exists)
 - `005_drop_bot_messages.py` — Drops the `bot_messages` table (superseded by `captured_events`; take a backup dump first — no-op once dropped)
 - `006_channel_settings.py` — Creates the typed `channel_settings` table (the settings-split) and seeds the `__default__` / `__default_dm__` policy rows. Channel-specific overrides are environment data — applied manually, never in the migration.
+- `007_environment_meta.py` — Creates the `meta` table and stamps the database's environment (`dev`/`prod`). The bot asserts a match at startup and refuses to run against a mismatched database; this migration refuses to re-stamp a database already marked as a different environment.
 
 To run each:
 
@@ -18,6 +19,7 @@ poetry run python migrations/003_conversants_list_to_dict.py
 poetry run python migrations/004_captured_events.py
 poetry run python migrations/005_drop_bot_messages.py
 poetry run python migrations/006_channel_settings.py --env dev   # or --env prod
+poetry run python migrations/007_environment_meta.py --env dev    # or --env prod
 ```
 
 > **From 006 onward**, migrations require an explicit `--env dev|prod` flag and

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -28,6 +28,8 @@ class TestAdminCommands:
         bot.conversations = {}
         bot.debug_prompts = False
         bot.conversation = []  # Add this for the forget tests
+        # Settings setters write through to channel_settings (async).
+        bot.fdb.set_channel_setting = AsyncMock(return_value=True)
         return bot
 
     @pytest.fixture
@@ -329,8 +331,32 @@ class TestAdminCommands:
         assert mock_bot.conversations[conversation_id]["history_length"] == int(
             new_length
         )
+        mock_bot.fdb.set_channel_setting.assert_awaited_once_with(
+            conversation_id, "history_length", int(new_length)
+        )
         mock_message.channel.send.assert_called_once_with(
             f"History length set to: {new_length} for conversation {conversation_id}"
+        )
+
+    @pytest.mark.asyncio
+    @patch("admin_commands.admin", "test_admin")
+    async def test_set_history_length_for_specific_conversation(
+        self, setup_test_conversation, mock_message
+    ):
+        """Regression: `history <conversation_id> <length>` must set the LENGTH,
+        not parse the snowflake conversation id as the length (the old bug)."""
+        mock_bot = setup_test_conversation
+        target_id = "789012"
+        new_length = "30"
+        mock_message.content = f"{COMMAND_PREFIX}history {target_id} {new_length}"
+
+        await _set_history_length(
+            mock_bot, mock_message, ["history", target_id, new_length], "123456"
+        )
+
+        assert mock_bot.conversations[target_id]["history_length"] == 30
+        mock_bot.fdb.set_channel_setting.assert_awaited_once_with(
+            target_id, "history_length", 30
         )
 
     @pytest.mark.asyncio

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -30,6 +30,21 @@ class TestFaebot:
             bot.fdb.connect = AsyncMock(return_value=True)
             bot.fdb.close = AsyncMock(return_value=True)
             bot.fdb.load_conversations = AsyncMock(return_value={})
+
+            # Settings-split: the bot pulls the four dials from channel_settings
+            # per message. Mock the inheritance — DMs differ in freq+template.
+            async def fake_effective_settings(conversation_id, is_dm=False):
+                return {
+                    "model": "moonshotai/kimi-k2",
+                    "reply_frequency": 1.0 if is_dm else 0.05,
+                    "history_length": 69,
+                    "prompt_template": "dm" if is_dm else "default",
+                }
+
+            bot.fdb.get_effective_settings = AsyncMock(
+                side_effect=fake_effective_settings
+            )
+            bot.fdb.set_channel_setting = AsyncMock(return_value=True)
             # Use patch to override the user property
             user_mock = Mock()
             user_mock.id = 12345
@@ -129,8 +144,12 @@ class TestFaebot:
         assert conv["conversants"] == {
             mock_message.author.name: mock_message.author.display_name
         }
+        # Settings are inherited from channel_settings, not stamped at creation.
         assert conv["reply_frequency"] == 0.05
-        assert conv["prompt_template"] == DEFAULT_TEMPLATE
+        assert conv["prompt_template"] == "default"
+        assert conv["model"] == "moonshotai/kimi-k2"
+        assert conv["history_length"] == 69
+        faebot.fdb.get_effective_settings.assert_awaited_with(conversation_id, False)
         mock_message.channel.send.assert_called_once()
 
     @pytest.mark.asyncio
@@ -153,7 +172,10 @@ class TestFaebot:
 
         assert conversation_id in faebot.conversations
         conv = faebot.conversations[conversation_id]
+        # DM inherits __default_dm__: frequency 1, template 'dm'.
         assert conv["reply_frequency"] == 1
+        assert conv["prompt_template"] == "dm"
+        faebot.fdb.get_effective_settings.assert_awaited_with(conversation_id, True)
         assert conv["prompt_template"] == "dm"
         dm_message.channel.send.assert_called_once()
 

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -1,6 +1,7 @@
 import asyncio
 import pytest
 import os
+import discord
 from unittest.mock import AsyncMock, Mock, patch
 from faediscord import Faebot, COMMAND_PREFIX, PROMPT_TEMPLATES, DEFAULT_TEMPLATE
 import sys
@@ -63,9 +64,9 @@ class TestFaebot:
         message.author.display_name = "Test User"
         message.content = "test message"
         message.channel = Mock()
+        message.channel.__class__ = discord.TextChannel  # satisfies isinstance
         message.channel.id = 123456789
         message.channel.name = "test-channel"
-        message.channel.type = ["text"]
         message.channel.send = AsyncMock()
         message.created_at = Mock()
         message.created_at.strftime.return_value = "2024-01-01 12:00:00"
@@ -160,8 +161,8 @@ class TestFaebot:
         dm_message.author = Mock()
         dm_message.author.name = "test_user"
         dm_message.channel = Mock()
+        dm_message.channel.__class__ = discord.DMChannel  # satisfies isinstance
         dm_message.channel.id = 987654321
-        dm_message.channel.type = ["private"]
         dm_message.channel.send = AsyncMock()
 
         conversation_id = str(dm_message.channel.id)

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -30,6 +30,7 @@ class TestFaebot:
             bot.fdb.get_conversation = AsyncMock(return_value=None)
             bot.fdb.connect = AsyncMock(return_value=True)
             bot.fdb.close = AsyncMock(return_value=True)
+            bot.fdb.assert_environment = AsyncMock(return_value=None)
             bot.fdb.load_conversations = AsyncMock(return_value={})
 
             # Settings-split: the bot pulls the four dials from channel_settings


### PR DESCRIPTION
## The settings split: per-channel dials become data

Settings (model, reply_frequency, history_length, prompt_template) move out of the JSONB metadata blob (stamped at creation, editable only via fragile DM commands) into a typed `channel_settings` table that the database defends with CHECK constraints and any interface can read/write. **Deployed and verified live** (machine-general dissolved from a cemented `mythomax-l2-13b` to the inherited kimi default without touching its blob; live per-channel edits persist and take effect on the next message).

### The model
- Typed columns; `NULL = inherit`. Two policy rows: `__default__` (guild) and `__default_dm__` (its NULLs fall through to `__default__`). Effective setting = `COALESCE(override, [dm_default,] default)`.
- No row = fully inherited. Editing `__default__` retunes every non-overriding channel at once.
- Bot re-reads a channel's settings **per incoming message**, so edits (fae; command, future CLI/slash, another process) apply with no restart.

### What changed
- `get_effective_settings` / `set_channel_setting` (inheritance resolution + whitelisted-column write-through).
- Read path: per-message refresh; creation stops stamping settings (inherits instead).
- Write path: fae; setters write through to the DB. **Fixes the `fae;history <id> <n>` snowflake-as-length corruption** (regression-tested).
- `save_conversation`: blob holds identity only (name/conversants); the shrink-guard that broke `forget` and history-shrink is gone — plain upsert.
- Migration 006 (table + policy rows); channel overrides applied as environment data, never in a migration.

### Bundled hardening (same story)
- **Stale-shell disarm**: explicit `DEV_/PROD_DATABASE_URL` (no ambient `DATABASE_URL` on dev), migrations require `--env` + announce their target, and **migration 007 stamps the DB's environment** — the bot asserts a match at startup and refuses a mismatched database (the layer no naming discipline can replace).
- **kimi-k2 silent-generation fix**: `reasoning:{enabled:false}` in the OpenRouter payload — some providers (Novita) burned the whole token budget on hidden reasoning and returned empty text. Matters because this story makes kimi the default. Verified live: empty → coherent output.
- Cleanup: `isinstance` channel checks, exact-Decimal frequency storage, dead prompt `.txt` files removed.

63 tests pass. Migrations 006+007 run on dev and prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
