### PR TITLE
see-and-edit step 5: the settings CLI, and conversations learn where they live

### DIFF
--- a/backfill_locations.py
+++ b/backfill_locations.py
@@ -46,7 +46,9 @@ def resolve_database_url(environment: str) -> str:
     return database_url
 
 
-async def guild_name(client: discord.Client, guild_id: int, cache: dict) -> str | None:
+async def guild_name(
+    client: discord.Client, guild_id: int, cache: dict[int, str | None]
+) -> str | None:
     """Fetch a guild's NAME over REST.
 
     Without a gateway connection there is no guild cache, so the `.guild` on a
@@ -63,15 +65,17 @@ async def guild_name(client: discord.Client, guild_id: int, cache: dict) -> str 
     return cache[guild_id]
 
 
-async def locate(client: discord.Client, conversation_id: str, cache: dict) -> dict | None:
+async def locate(
+    client: discord.Client, conversation_id: str, cache: dict[int, str | None]
+) -> dict | None:
     """Ask Discord where this conversation lives. None = couldn't tell."""
     try:
         channel = await client.fetch_channel(int(conversation_id))
     except discord.NotFound:
-        print(f"    not found (deleted channel, or bot removed) — leaving unrecorded")
+        print("    not found (deleted channel, or bot removed) — leaving unrecorded")
         return None
     except discord.Forbidden:
-        print(f"    no access (bot can't see it) — leaving unrecorded")
+        print("    no access (bot can't see it) — leaving unrecorded")
         return None
     except (discord.HTTPException, ValueError) as error:
         print(f"    lookup failed: {error} — leaving unrecorded")
@@ -104,16 +108,16 @@ async def backfill(environment: str, write: bool) -> None:
         "OR conversation_metadata ? 'is_dm'"
     )
     total = await connection.fetchval("SELECT count(*) FROM conversations")
-    print(f"Found {total} conversations, {stamped} already located, "
-          f"{total - stamped} to look up.")
+    print(
+        f"Found {total} conversations, {stamped} already located, "
+        f"{total - stamped} to look up."
+    )
     if total == stamped:
         print("Nothing to backfill.")
         await connection.close()
         return
 
-    rows = await connection.fetch(
-        "SELECT id, conversation_metadata FROM conversations"
-    )
+    rows = await connection.fetch("SELECT id, conversation_metadata FROM conversations")
 
     client = discord.Client(intents=discord.Intents.default())
     await client.login(token)
@@ -134,27 +138,34 @@ async def backfill(environment: str, write: bool) -> None:
             if location is None:
                 continue
 
-            where = "DM" if location["is_dm"] else f"{location['guild_name']} ({location['guild_id']})"
+            where = (
+                "DM"
+                if location["is_dm"]
+                else f"{location['guild_name']} ({location['guild_id']})"
+            )
             print(f"    → {where}")
             located += 1
             if not write:
                 continue
 
-            metadata.update({
-                key: value for key, value in location.items() if value is not None
-            })
+            metadata.update(
+                {key: value for key, value in location.items() if value is not None}
+            )
             if location["is_dm"]:
                 metadata["is_dm"] = True
             await connection.execute(
                 "UPDATE conversations SET conversation_metadata = $1 WHERE id = $2",
-                json.dumps(metadata), row["id"],
+                json.dumps(metadata),
+                row["id"],
             )
     finally:
         await client.close()
 
     verb = "located" if write else "would locate"
-    print(f"\n{verb} {located} conversations."
-          + ("" if write else "  (dry run — pass --write to apply)"))
+    print(
+        f"\n{verb} {located} conversations."
+        + ("" if write else "  (dry run — pass --write to apply)")
+    )
     if write:
         now_stamped = await connection.fetchval(
             "SELECT count(*) FROM conversations WHERE conversation_metadata ? 'guild_id' "
@@ -167,8 +178,9 @@ async def backfill(environment: str, write: bool) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--env", required=True, choices=["dev", "prod"])
-    parser.add_argument("--write", action="store_true",
-                        help="actually write (default is a dry run)")
+    parser.add_argument(
+        "--write", action="store_true", help="actually write (default is a dry run)"
+    )
     arguments = parser.parse_args()
     asyncio.run(backfill(arguments.env, arguments.write))
 

--- a/backfill_locations.py
+++ b/backfill_locations.py
@@ -1,0 +1,177 @@
+"""backfill_locations.py — one-off: record WHERE each conversation lives.
+
+From 2026-07-20 the bot stamps `guild_id` / `guild_name` / `is_dm` into a
+conversation's metadata on every message, so active channels heal themselves.
+Dormant channels never save, so they would stay unlocated forever — this
+script asks Discord once and fills them in.
+
+    poetry run python backfill_locations.py --env prod              # dry run
+    poetry run python backfill_locations.py --env prod --write      # do it
+
+Idempotent + diagnostic (house rule): reports counts before and after, only
+touches conversations MISSING the fields, and is safe to re-run. Default is a
+dry run — nothing is written without --write.
+
+Needs DISCORD_TOKEN (the bot's own, from the secrets file) plus the usual
+DEV_/PROD_DATABASE_URL. This is the ONLY tool here that talks to Discord; the
+settings CLI stays database-only on purpose.
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+
+import asyncpg
+import discord
+
+logging.basicConfig(level=logging.WARNING, format="%(message)s")
+
+LOCATION_KEYS = ("guild_id", "guild_name", "is_dm")
+
+
+def resolve_database_url(environment: str) -> str:
+    variable = "PROD_DATABASE_URL" if environment == "prod" else "DEV_DATABASE_URL"
+    database_url = os.getenv(variable, "")
+    if not database_url:
+        sys.exit(
+            f"{variable} is not set — source ../secrets/{environment}"
+            f"_discord_secrets.fish first"
+        )
+    if "localhost:5432" in database_url and "sslmode" not in database_url:
+        joiner = "&" if "?" in database_url else "?"
+        database_url += f"{joiner}sslmode=disable"
+    return database_url
+
+
+async def guild_name(client: discord.Client, guild_id: int, cache: dict) -> str | None:
+    """Fetch a guild's NAME over REST.
+
+    Without a gateway connection there is no guild cache, so the `.guild` on a
+    fetched channel is a stub carrying only an id — the name needs its own
+    call. Cached here because a handful of channels share a few servers.
+    """
+    if guild_id in cache:
+        return cache[guild_id]
+    try:
+        cache[guild_id] = (await client.fetch_guild(guild_id)).name
+    except (discord.Forbidden, discord.NotFound, discord.HTTPException) as error:
+        print(f"    (couldn't read server name: {error})")
+        cache[guild_id] = None
+    return cache[guild_id]
+
+
+async def locate(client: discord.Client, conversation_id: str, cache: dict) -> dict | None:
+    """Ask Discord where this conversation lives. None = couldn't tell."""
+    try:
+        channel = await client.fetch_channel(int(conversation_id))
+    except discord.NotFound:
+        print(f"    not found (deleted channel, or bot removed) — leaving unrecorded")
+        return None
+    except discord.Forbidden:
+        print(f"    no access (bot can't see it) — leaving unrecorded")
+        return None
+    except (discord.HTTPException, ValueError) as error:
+        print(f"    lookup failed: {error} — leaving unrecorded")
+        return None
+
+    guild = getattr(channel, "guild", None)
+    if guild is None:
+        return {"guild_id": None, "guild_name": None, "is_dm": True}
+    return {
+        "guild_id": str(guild.id),
+        "guild_name": await guild_name(client, guild.id, cache),
+        "is_dm": False,
+    }
+
+
+async def backfill(environment: str, write: bool) -> None:
+    # Tokens follow the same disarm as the database URLs: prod's lives under a
+    # distinct name so a dev-shaped invocation cannot pick it up by accident.
+    token_variable = "DISCORD_TOKEN_PROD" if environment == "prod" else "DISCORD_TOKEN"
+    token = os.getenv(token_variable, "")
+    if not token:
+        sys.exit(
+            f"{token_variable} is not set — source ../secrets/{environment}"
+            f"_discord_secrets.fish first"
+        )
+
+    connection = await asyncpg.connect(resolve_database_url(environment))
+    stamped = await connection.fetchval(
+        "SELECT count(*) FROM conversations WHERE conversation_metadata ? 'guild_id' "
+        "OR conversation_metadata ? 'is_dm'"
+    )
+    total = await connection.fetchval("SELECT count(*) FROM conversations")
+    print(f"Found {total} conversations, {stamped} already located, "
+          f"{total - stamped} to look up.")
+    if total == stamped:
+        print("Nothing to backfill.")
+        await connection.close()
+        return
+
+    rows = await connection.fetch(
+        "SELECT id, conversation_metadata FROM conversations"
+    )
+
+    client = discord.Client(intents=discord.Intents.default())
+    await client.login(token)
+
+    located = 0
+    name_cache: dict[int, str | None] = {}
+    try:
+        for row in rows:
+            metadata = row["conversation_metadata"]
+            if isinstance(metadata, str):
+                metadata = json.loads(metadata)
+            if any(key in metadata for key in LOCATION_KEYS):
+                continue  # already located — idempotent
+
+            name = metadata.get("name", "?")
+            print(f"  {name} ({row['id']})")
+            location = await locate(client, row["id"], name_cache)
+            if location is None:
+                continue
+
+            where = "DM" if location["is_dm"] else f"{location['guild_name']} ({location['guild_id']})"
+            print(f"    → {where}")
+            located += 1
+            if not write:
+                continue
+
+            metadata.update({
+                key: value for key, value in location.items() if value is not None
+            })
+            if location["is_dm"]:
+                metadata["is_dm"] = True
+            await connection.execute(
+                "UPDATE conversations SET conversation_metadata = $1 WHERE id = $2",
+                json.dumps(metadata), row["id"],
+            )
+    finally:
+        await client.close()
+
+    verb = "located" if write else "would locate"
+    print(f"\n{verb} {located} conversations."
+          + ("" if write else "  (dry run — pass --write to apply)"))
+    if write:
+        now_stamped = await connection.fetchval(
+            "SELECT count(*) FROM conversations WHERE conversation_metadata ? 'guild_id' "
+            "OR conversation_metadata ? 'is_dm'"
+        )
+        print(f"Located conversations: {stamped} → {now_stamped}.")
+    await connection.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env", required=True, choices=["dev", "prod"])
+    parser.add_argument("--write", action="store_true",
+                        help="actually write (default is a dry run)")
+    arguments = parser.parse_args()
+    asyncio.run(backfill(arguments.env, arguments.write))
+
+
+if __name__ == "__main__":
+    main()

--- a/capture.py
+++ b/capture.py
@@ -38,7 +38,12 @@ from typing import Any, Dict, Optional
 
 
 # Default-on: only an explicitly truthy CAPTURE_DISABLED turns capture off.
-CAPTURE_ENABLED = os.getenv("CAPTURE_DISABLED", "").strip().lower() in ("", "0", "false", "no")
+CAPTURE_ENABLED = os.getenv("CAPTURE_DISABLED", "").strip().lower() in (
+    "",
+    "0",
+    "false",
+    "no",
+)
 RAW_ENABLED = CAPTURE_ENABLED and os.getenv("CAPTURE_RAW", "1") != "0"
 
 # The database handle is injected at startup (see init) to avoid a circular import.

--- a/database.py
+++ b/database.py
@@ -437,7 +437,10 @@ class FaebotDatabase:
                 logging.warning(
                     "⚠️ No value for '%s' in channel_settings (channel %s) — "
                     "using emergency default %r. The %s row may need fixing.",
-                    column, conversation_id, value, DEFAULT_ROW,
+                    column,
+                    conversation_id,
+                    value,
+                    DEFAULT_ROW,
                 )
             resolved[column] = value
 
@@ -455,7 +458,9 @@ class FaebotDatabase:
         if key not in SETTINGS_COLUMNS:
             raise ValueError(f"unknown setting {key!r}")
         if not self.pool:
-            logging.warning("No database pool — cannot set %s for %s", key, conversation_id)
+            logging.warning(
+                "No database pool — cannot set %s for %s", key, conversation_id
+            )
             return False
 
         async with self.pool.acquire() as conn:
@@ -469,9 +474,7 @@ class FaebotDatabase:
                 conversation_id,
                 value,
             )
-        logging.info(
-            "✅ channel_settings: %s.%s = %r", conversation_id, key, value
-        )
+        logging.info("✅ channel_settings: %s.%s = %r", conversation_id, key, value)
         return True
 
     @with_retry()

--- a/database.py
+++ b/database.py
@@ -235,6 +235,14 @@ class FaebotDatabase:
                 "name": conversation_data["name"],
                 "conversants": conversation_data.get("conversants", {}),
             }
+            # Where this conversation LIVES (2026-07-20): guild id/name and
+            # whether it's a DM — identity, like the name, so it rides in the
+            # blob. Only written when known, because this write replaces the
+            # whole blob: a save from a path that never stamped them must not
+            # erase what an earlier stamped save recorded.
+            for location_key in ("guild_id", "guild_name", "is_dm"):
+                if conversation_data.get(location_key) is not None:
+                    metadata[location_key] = conversation_data[location_key]
             history = conversation_data.get("conversation", [])
 
             async with self.pool.acquire() as conn:
@@ -316,6 +324,11 @@ class FaebotDatabase:
                             "model": metadata.get(
                                 "model", "google/gemini-2.0-flash-001"
                             ),
+                            # Location, carried back into memory so a later
+                            # save doesn't drop what a previous one recorded.
+                            "guild_id": metadata.get("guild_id"),
+                            "guild_name": metadata.get("guild_name"),
+                            "is_dm": metadata.get("is_dm"),
                         }
                         successful += 1
                         logging.debug(

--- a/faediscord.py
+++ b/faediscord.py
@@ -15,7 +15,7 @@ import capture
 import time
 
 
-model = os.getenv("MODEL_NAME", "google/gemini-2.0-flash-001")  # Updated default model
+model = os.getenv("MODEL_NAME", "moonshotai/kimi-k2")  # Updated default model
 admin = os.getenv("ADMIN", "")
 env = os.getenv("ENVIRONMENT", "dev").lower()
 
@@ -427,6 +427,17 @@ class Faebot(discord.Client):
             # Settings first: refresh from channel_settings so every downstream
             # read (trim, respond-dice, generation) sees live-edited values.
             await self._refresh_channel_settings(message, conversation_id)
+
+            # Stamp WHERE this conversation lives, every message, so it
+            # self-heals for conversations that predate the field (the same
+            # lazy cleanup the settings split relied on). A DM has no guild —
+            # recording that is what lets any reader resolve DM inheritance
+            # without asking Discord. Stamped before the periodic save below
+            # so it lands at the first opportunity.
+            conversation = self.conversations[conversation_id]
+            conversation["guild_id"] = str(message.guild.id) if message.guild else None
+            conversation["guild_name"] = message.guild.name if message.guild else None
+            conversation["is_dm"] = message.guild is None
 
             # Check if we should do a periodic save (every 10 messages or 5 minutes)
             if conversation_id in self.conversations:

--- a/faediscord.py
+++ b/faediscord.py
@@ -276,7 +276,9 @@ class Faebot(discord.Client):
         if capture.is_enabled():
             logging.info("🎥 CAPTURE ON — recording raw events to captured_events")
         else:
-            logging.warning("⚠️ capture OFF (CAPTURE_DISABLED is set — faebot is not recording)")
+            logging.warning(
+                "⚠️ capture OFF (CAPTURE_DISABLED is set — faebot is not recording)"
+            )
         logging.info("------")
 
     # --- spike-01 capture delegates -------------------------------------------

--- a/migrations/005_drop_bot_messages.py
+++ b/migrations/005_drop_bot_messages.py
@@ -36,7 +36,9 @@ async def migrate():
         # Announce the target BEFORE acting — DATABASE_URL is trusted blindly,
         # and a mis-sourced environment once pointed a migration at the wrong
         # database (2026-07-06). Make the blast zone legible.
-        target = await conn.fetchrow("SELECT current_user AS usr, current_database() AS db")
+        target = await conn.fetchrow(
+            "SELECT current_user AS usr, current_database() AS db"
+        )
         logging.info(f"Target: {target['usr']} @ {target['db']}")
 
         exists = await conn.fetchval(
@@ -51,7 +53,9 @@ async def migrate():
             count = await conn.fetchval("SELECT COUNT(*) FROM bot_messages")
             logging.info(f"bot_messages exists with {count} rows — dropping")
             await conn.execute("DROP TABLE bot_messages")
-            logging.info(f"✅ bot_messages dropped ({count} rows retired; recoverable from dumps)")
+            logging.info(
+                f"✅ bot_messages dropped ({count} rows retired; recoverable from dumps)"
+            )
         else:
             logging.info("bot_messages does not exist — nothing to migrate")
 

--- a/migrations/006_channel_settings.py
+++ b/migrations/006_channel_settings.py
@@ -44,14 +44,20 @@ def resolve_database_url() -> str:
     prod_discord_secrets.fish). Pattern for all migrations from 006 onward.
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument("--env", required=True, choices=["dev", "prod"],
-                        help="which database this migration targets")
+    parser.add_argument(
+        "--env",
+        required=True,
+        choices=["dev", "prod"],
+        help="which database this migration targets",
+    )
     arguments = parser.parse_args()
 
     variable = "PROD_DATABASE_URL" if arguments.env == "prod" else "DEV_DATABASE_URL"
     database_url = os.getenv(variable, "")
     if not database_url:
-        sys.exit(f"{variable} is not set — source ../secrets/{arguments.env}_discord_secrets.fish first")
+        sys.exit(
+            f"{variable} is not set — source ../secrets/{arguments.env}_discord_secrets.fish first"
+        )
     logging.info(f"Requested environment: {arguments.env} (via {variable})")
 
     if "localhost:5432" in database_url:

--- a/migrations/007_environment_meta.py
+++ b/migrations/007_environment_meta.py
@@ -26,14 +26,20 @@ logging.basicConfig(level=logging.INFO)
 def resolve() -> tuple[str, str]:
     """Return (requested_env, database_url); require an explicit --env."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("--env", required=True, choices=["dev", "prod"],
-                        help="which database this migration targets + stamps")
+    parser.add_argument(
+        "--env",
+        required=True,
+        choices=["dev", "prod"],
+        help="which database this migration targets + stamps",
+    )
     arguments = parser.parse_args()
 
     variable = "PROD_DATABASE_URL" if arguments.env == "prod" else "DEV_DATABASE_URL"
     database_url = os.getenv(variable, "")
     if not database_url:
-        sys.exit(f"{variable} is not set — source ../secrets/{arguments.env}_discord_secrets.fish first")
+        sys.exit(
+            f"{variable} is not set — source ../secrets/{arguments.env}_discord_secrets.fish first"
+        )
     if "localhost:5432" in database_url:
         database_url += (
             "?sslmode=disable" if "?" not in database_url else "&sslmode=disable"

--- a/settings_cli.py
+++ b/settings_cli.py
@@ -1,0 +1,461 @@
+"""settings_cli.py — the see-and-edit instrument (step 5 of the story).
+
+Read (and soon set) per-channel dials without spamming a channel or fighting
+DM commands. Talks to Postgres directly — through `fly proxy` for prod — so
+there is NO new attack surface on the bot, and the tool survives the move off
+fly (faebot's own computer, ~2026-08-06).
+
+    poetry run python settings_cli.py show --env dev
+    poetry run python settings_cli.py show --env prod    # needs fly proxy open
+
+The inheritance rules are NOT reimplemented here: this calls the bot's own
+`FaebotDatabase.get_effective_settings()`, so the instrument and the bot can
+never drift apart. What the CLI adds is the *overview* — every channel at
+once, with each value marked as its own override or inherited from policy.
+
+Environment (the stale-shell disarm, 2026-07-07): --env is required and picks
+which explicit variable to read — DEV_DATABASE_URL / PROD_DATABASE_URL, the
+names the secrets files provide. Nothing ambient. The connected database is
+then checked against its own `meta` stamp (migration 007), so a proxy pointed
+at the wrong world fails loudly instead of quietly editing production.
+
+Known gap (2026-07-20): the database does not record whether a conversation
+is a DM, so this tool resolves every channel by the guild rules (own row ->
+__default__). DMs additionally inherit __default_dm__ in the live bot; both
+policy rows are printed so the DM answer is readable, and `--dm` forces DM
+resolution for a single channel.
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from decimal import Decimal
+
+import asyncpg
+
+from database import (
+    DEFAULT_DM_ROW,
+    DEFAULT_ROW,
+    SETTINGS_COLUMNS,
+    FaebotDatabase,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+POLICY_ROWS = (DEFAULT_ROW, DEFAULT_DM_ROW)
+
+
+def resolve_database_url(environment: str) -> str:
+    """Read the explicit variable for this environment, or exit saying which."""
+    variable = "PROD_DATABASE_URL" if environment == "prod" else "DEV_DATABASE_URL"
+    database_url = os.getenv(variable, "")
+    if not database_url:
+        sys.exit(
+            f"{variable} is not set — source ../secrets/{environment}"
+            f"_discord_secrets.fish first"
+        )
+    if "localhost:5432" in database_url and "sslmode" not in database_url:
+        joiner = "&" if "?" in database_url else "?"
+        database_url += f"{joiner}sslmode=disable"
+    return database_url
+
+
+async def open_database(environment: str) -> FaebotDatabase:
+    """Connect with the CLI's own env resolution, then verify the DB agrees."""
+    database = FaebotDatabase()
+    # FaebotDatabase picks DATABASE_URL/DEV_DATABASE_URL from the bot's own
+    # ENVIRONMENT; the CLI says which world it means on the command line
+    # instead, so the resolved URL is assigned explicitly here.
+    database.database_url = resolve_database_url(environment)
+    await database.connect()
+    if not database.pool:
+        sys.exit("could not connect — is the fly proxy open? (pgprobe --fly)")
+    await database.assert_environment(environment)
+    return database
+
+
+async def load_channels(database: FaebotDatabase) -> list[dict]:
+    """Every conversation with its name, newest activity first."""
+    async with database.pool.acquire() as connection:
+        rows = await connection.fetch(
+            "SELECT id, conversation_metadata, last_updated FROM conversations"
+        )
+    channels = []
+    for row in rows:
+        metadata = row["conversation_metadata"]
+        if isinstance(metadata, str):
+            metadata = json.loads(metadata)
+        channels.append(
+            {
+                "id": row["id"],
+                "name": metadata.get("name", "?"),
+                "last_updated": row["last_updated"],
+                "guild_id": metadata.get("guild_id"),
+                "guild_name": metadata.get("guild_name"),
+                "is_dm": metadata.get("is_dm"),
+            }
+        )
+    return sorted(channels, key=lambda channel: channel["name"].lower())
+
+
+DM_GROUP = "direct messages"
+UNKNOWN_GROUP = (
+    "server not recorded yet — heals when faebot next speaks there, "
+    "or run backfill_locations.py"
+)
+
+
+async def load_overrides(database: FaebotDatabase) -> dict[str, dict]:
+    """Raw channel_settings rows — which fields a channel sets for itself."""
+    async with database.pool.acquire() as connection:
+        rows = await connection.fetch("SELECT * FROM channel_settings")
+    return {row["conversation_id"]: dict(row) for row in rows}
+
+
+def format_value(column: str, value) -> str:
+    if value is None:
+        return "—"
+    if column == "reply_frequency":
+        return f"{float(value):.2f}"
+    return str(value)
+
+
+async def show(environment: str, dm: bool) -> None:
+    database = await open_database(environment)
+    try:
+        channels = await load_channels(database)
+        overrides = await load_overrides(database)
+
+        header = f"{'channel':<24} {'id':<20} {'model':<22} {'freq':>6} {'hist':>5} {'template':<9} {'last activity':<16}"
+
+        # Group by where the conversation lives: the answer to "which room is
+        # this, really" — duplicate channel NAMES across servers are normal
+        # (the old embassy's faebots-room sits armed beside the live one).
+        # Name AND id, because humans read names and ids disambiguate.
+        def group_of(channel: dict) -> str:
+            if channel["is_dm"]:
+                return DM_GROUP
+            if not channel["guild_id"]:
+                return UNKNOWN_GROUP
+            name = channel["guild_name"] or "(unnamed server)"
+            return f"{name}  ({channel['guild_id']})"
+
+        by_group: dict[str, list[dict]] = {}
+        for channel in channels:
+            by_group.setdefault(group_of(channel), []).append(channel)
+
+        def group_sort_key(item):
+            group, members = item
+            unresolved = group in (DM_GROUP, UNKNOWN_GROUP)
+            return (unresolved, group == UNKNOWN_GROUP, -len(members), group)
+
+        for group, members in sorted(by_group.items(), key=group_sort_key):
+            print()
+            print(f"▸ {group}")
+            print(header)
+            print("─" * len(header))
+            for channel in members:
+                # Per-channel DM resolution once recorded; --dm forces it for
+                # conversations that haven't healed yet.
+                is_dm = channel["is_dm"] if channel["is_dm"] is not None else dm
+                settings = await database.get_effective_settings(channel["id"], is_dm=is_dm)
+                own = overrides.get(channel["id"], {})
+                cells = []
+                for column in SETTINGS_COLUMNS:
+                    mark = "*" if own.get(column) is not None else "·"
+                    cells.append((mark, format_value(column, settings[column])))
+                print(
+                    f"{channel['name'][:23]:<24} {channel['id']:<20} "
+                    f"{cells[0][0]}{cells[0][1][:21]:<21} "
+                    f"{cells[1][0]}{cells[1][1]:>5} "
+                    f"{cells[2][0]}{cells[2][1]:>4} "
+                    f"{cells[3][0]}{cells[3][1][:8]:<8} "
+                    f"{str(channel['last_updated'])[:16]:<16}"
+                )
+
+        print()
+        print("─" * len(header))
+        for policy_id in POLICY_ROWS:
+            row = overrides.get(policy_id)
+            if not row:
+                print(f"{policy_id:<24} (missing! run migration 006)")
+                continue
+            values = " ".join(
+                f"{column.split('_')[0]}={format_value(column, row[column])}"
+                for column in SETTINGS_COLUMNS
+            )
+            print(f"{policy_id:<24} {values}")
+        print()
+        print(f"  * = set on this channel   · = inherited   — = unset")
+        print(
+            f"  resolution: {'DM (own → __default_dm__ → __default__)' if dm else 'guild (own → __default__)'}"
+        )
+        print()
+    finally:
+        await database.close()
+
+
+# Friendly names accepted alongside the real column names, so what `show`
+# prints and what `set` takes never diverge.
+PROPERTY_ALIASES = {
+    "model": "model",
+    "frequency": "reply_frequency",
+    "reply_frequency": "reply_frequency",
+    "history": "history_length",
+    "history_length": "history_length",
+    "template": "prompt_template",
+    "prompt_template": "prompt_template",
+}
+
+
+# The short name shown back to the user for each column.
+FRIENDLY_NAMES = {
+    "model": "model",
+    "reply_frequency": "frequency",
+    "history_length": "history",
+    "prompt_template": "template",
+}
+
+
+def resolve_property(name: str) -> str:
+    if name not in PROPERTY_ALIASES:
+        sys.exit(
+            f"unknown property {name!r} — one of: "
+            + ", ".join(sorted(set(PROPERTY_ALIASES)))
+        )
+    return PROPERTY_ALIASES[name]
+
+
+def coerce(column: str, raw: str):
+    """Text from the command line -> the type the column actually stores."""
+    try:
+        if column == "reply_frequency":
+            return Decimal(raw)  # NUMERIC: asyncpg wants Decimal, not float
+        if column == "history_length":
+            return int(raw)
+    except (ArithmeticError, ValueError):
+        sys.exit(f"{raw!r} is not a valid value for {column}")
+    return raw
+
+
+async def load_constraints(database: FaebotDatabase) -> dict[str, str]:
+    """The CHECK constraints, quoted back as hints — the DB is the truth."""
+    async with database.pool.acquire() as connection:
+        rows = await connection.fetch(
+            "SELECT pg_get_constraintdef(oid) AS definition FROM pg_constraint "
+            "WHERE conrelid = 'channel_settings'::regclass AND contype = 'c'"
+        )
+    hints: dict[str, str] = {}
+    for row in rows:
+        definition = row["definition"]
+        for column in SETTINGS_COLUMNS:
+            if column in definition:
+                hints[column] = definition
+    return hints
+
+
+async def describe(database: FaebotDatabase, conversation_id: str) -> dict | None:
+    """Name + location for a conversation id; None if it isn't one we know."""
+    for channel in await load_channels(database):
+        if channel["id"] == conversation_id:
+            return channel
+    return None
+
+
+async def count_inheritors(database: FaebotDatabase, column: str,
+                           policy_row: str) -> int:
+    """How many conversations would feel a change to this policy row."""
+    channels = await load_channels(database)
+    overrides = await load_overrides(database)
+    affected = 0
+    for channel in channels:
+        own = overrides.get(channel["id"], {})
+        if own.get(column) is not None:
+            continue  # sets its own — unaffected
+        if policy_row == DEFAULT_DM_ROW and not channel["is_dm"]:
+            continue
+        if policy_row == DEFAULT_ROW and channel["is_dm"]:
+            dm_policy = overrides.get(DEFAULT_DM_ROW, {})
+            if dm_policy.get(column) is not None:
+                continue  # the DM policy already answers for them
+        affected += 1
+    return affected
+
+
+def label_for(channel: dict | None, conversation_id: str) -> str:
+    if conversation_id in POLICY_ROWS:
+        return f"{conversation_id} (policy row)"
+    if not channel:
+        return conversation_id
+    if channel["is_dm"]:
+        return f"{channel['name']} (DM)"
+    where = channel["guild_name"] or channel["guild_id"] or "server unrecorded"
+    return f"{channel['name']} ({where})"
+
+
+async def write_setting(environment: str, conversation_id: str | None,
+                        property_name: str | None, value: str | None,
+                        clearing: bool) -> None:
+    """set/unset, with a ladder of errors that each teach the next step."""
+    database = await open_database(environment)
+    try:
+        command = "unset" if clearing else "set"
+
+        if not conversation_id:
+            sys.exit(
+                "which channel? pass --id <conversation id>\n"
+                f"  run:  settings_cli.py show --env {environment}    to list them\n"
+                f"  policy rows are ids too: {DEFAULT_ROW}, {DEFAULT_DM_ROW}"
+            )
+
+        channel = await describe(database, conversation_id)
+        if not channel and conversation_id not in POLICY_ROWS:
+            sys.exit(
+                f"no conversation {conversation_id!r} — check the id against "
+                f"`show --env {environment}`"
+            )
+        heading = label_for(channel, conversation_id)
+
+        overrides = await load_overrides(database)
+        own = overrides.get(conversation_id, {})
+        is_dm = bool(channel["is_dm"]) if channel else conversation_id == DEFAULT_DM_ROW
+        effective = await database.get_effective_settings(conversation_id, is_dm=is_dm)
+
+        if not property_name:
+            lines = [f"{heading} — name a property:"]
+            for column in SETTINGS_COLUMNS:
+                mark = "*" if own.get(column) is not None else "·"
+                origin = "override" if own.get(column) is not None else "inherited"
+                friendly = FRIENDLY_NAMES[column]
+                lines.append(
+                    f"  --property {friendly:<10} currently {mark}"
+                    f"{format_value(column, effective[column]):<22} ({origin})"
+                )
+            sys.exit("\n".join(lines))
+
+        column = resolve_property(property_name)
+
+        if not clearing and value is None:
+            hints = await load_constraints(database)
+            inherited = "—"
+            if conversation_id not in POLICY_ROWS:
+                policy = overrides.get(
+                    DEFAULT_DM_ROW if is_dm else DEFAULT_ROW, {})
+                fallback = policy.get(column)
+                if fallback is None:
+                    fallback = overrides.get(DEFAULT_ROW, {}).get(column)
+                inherited = format_value(column, fallback)
+            message = [
+                f"{heading} · {column}",
+                f"  current:   {format_value(column, effective[column])}"
+                f"   ({'override on this channel' if own.get(column) is not None else 'inherited'})",
+            ]
+            if conversation_id not in POLICY_ROWS:
+                message.append(f"  inherited: {inherited}")
+            if column in hints:
+                message.append(f"  allowed:   {hints[column]}")
+            if conversation_id in POLICY_ROWS:
+                affected = await count_inheritors(database, column, conversation_id)
+                message.append(f"  inherited by: {affected} conversation(s)")
+            if conversation_id == DEFAULT_ROW:
+                # The base policy has nothing above it: clearing it drops the
+                # bot onto its emergency defaults, loudly. Not an unset target.
+                message.append("  pass --value <v>   (this row is the bottom of "
+                               "the chain — clearing it falls back to the bot's "
+                               "emergency defaults)")
+            else:
+                message.append(
+                    f"  pass --value <v>, or:  settings_cli.py unset --env {environment} "
+                    f"--id {conversation_id} --property {property_name}   to resume inheriting"
+                )
+            sys.exit("\n".join(message))
+
+        before = format_value(column, own.get(column))
+        new_value = None if clearing else coerce(column, value)
+
+        if conversation_id in POLICY_ROWS:
+            affected = await count_inheritors(database, column, conversation_id)
+            print(f"⚠ {conversation_id} is a POLICY row — {affected} conversation(s) "
+                  f"inherit {column} from it")
+
+        try:
+            # A CHECK refusal is an EXPECTED outcome here (the user typed a bad
+            # value), and it's translated below — so the bot's own "unexpected
+            # error" log line would be noise. Muted for this one call only.
+            logging.disable(logging.ERROR)
+            await database.set_channel_setting(conversation_id, column, new_value)
+        except asyncpg.exceptions.CheckViolationError:
+            # The database is the real guard; this just translates its refusal
+            # into the same hint the ladder shows.
+            hints = await load_constraints(database)
+            sys.exit(
+                f"refused: {format_value(column, new_value)} is not allowed for "
+                f"{column}\n  allowed: {hints.get(column, '(see the table CHECKs)')}"
+                f"\n  nothing was written."
+            )
+        finally:
+            logging.disable(logging.NOTSET)
+
+        after = format_value(column, new_value)
+        arrow = f"{before} → {after}"
+        note = " (now inheriting)" if clearing else " (override)"
+        print(f"{heading} · {column}: {arrow}{note}")
+
+        # Show what the channel now actually resolves to — an unset only shows
+        # its effect through the inheritance chain.
+        resolved = await database.get_effective_settings(conversation_id, is_dm=is_dm)
+        print(f"  effective now: {format_value(column, resolved[column])}")
+    finally:
+        await database.close()
+
+
+def main() -> None:
+    # --env lives on a shared parent so it reads naturally AFTER the
+    # subcommand: `settings_cli.py show --env dev`.
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--env", required=True, choices=["dev", "prod"],
+        help="which database to talk to (reads DEV_/PROD_DATABASE_URL)",
+    )
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    show_parser = subparsers.add_parser(
+        "show", parents=[common], help="table of every channel's settings")
+    show_parser.add_argument(
+        "--dm", action="store_true",
+        help="resolve with DM rules for conversations whose kind isn't recorded",
+    )
+
+    # set/unset share --id and --property; each argument is optional so a
+    # missing one can teach the next step instead of erroring blankly.
+    write_common = argparse.ArgumentParser(add_help=False, parents=[common])
+    write_common.add_argument("--id", help="conversation id (never the name — "
+                                           "names duplicate across servers)")
+    write_common.add_argument("--property",
+                              help="model | frequency | history | template")
+
+    set_parser = subparsers.add_parser(
+        "set", parents=[write_common], help="set one dial on one channel")
+    set_parser.add_argument("--value", help="the new value")
+    subparsers.add_parser(
+        "unset", parents=[write_common],
+        help="remove an override so the channel inherits again (and keeps "
+             "inheriting when the policy changes)")
+
+    arguments = parser.parse_args()
+
+    if arguments.command == "show":
+        asyncio.run(show(arguments.env, arguments.dm))
+    elif arguments.command in ("set", "unset"):
+        asyncio.run(write_setting(
+            arguments.env, arguments.id, arguments.property,
+            getattr(arguments, "value", None), clearing=arguments.command == "unset",
+        ))
+
+
+if __name__ == "__main__":
+    main()

--- a/settings_cli.py
+++ b/settings_cli.py
@@ -1,17 +1,31 @@
 """settings_cli.py — the see-and-edit instrument (step 5 of the story).
 
-Read (and soon set) per-channel dials without spamming a channel or fighting
-DM commands. Talks to Postgres directly — through `fly proxy` for prod — so
+Read and set per-channel dials without spamming a channel or fighting DM
+commands. Talks to Postgres directly — through `fly proxy` for prod — so
 there is NO new attack surface on the bot, and the tool survives the move off
 fly (faebot's own computer, ~2026-08-06).
 
-    poetry run python settings_cli.py show --env dev
-    poetry run python settings_cli.py show --env prod    # needs fly proxy open
+    poetry run python settings_cli.py show  --env prod          # needs fly proxy
+    poetry run python settings_cli.py set   --env prod --id <id> --property frequency --value 0.2
+    poetry run python settings_cli.py unset --env prod --id <id> --property frequency
+
+Run any of these with pieces missing and the error teaches the next step: no
+--id lists where to find one, --id alone lists the properties with their
+current values, --property alone shows current/inherited/allowed and writes
+nothing (a single-channel inspector, on purpose).
+
+set vs unset: `set` writes an override on this channel; `unset` REMOVES the
+override so the channel goes back to inheriting — and keeps inheriting when
+the policy row later changes. Copying today's default into a row is a
+different, usually-wrong thing, so there is no verb for it.
 
 The inheritance rules are NOT reimplemented here: this calls the bot's own
-`FaebotDatabase.get_effective_settings()`, so the instrument and the bot can
-never drift apart. What the CLI adds is the *overview* — every channel at
-once, with each value marked as its own override or inherited from policy.
+`get_effective_settings()` / `set_channel_setting()`, so the instrument and
+the bot cannot drift apart. What the CLI adds is the *overview* — every
+channel at once, grouped by server, each value marked as this channel's own
+override or inherited from policy. It reads only discord-owned tables;
+recovering anything from `captured_events` would couple these settings to
+core's raw material.
 
 Environment (the stale-shell disarm, 2026-07-07): --env is required and picks
 which explicit variable to read — DEV_DATABASE_URL / PROD_DATABASE_URL, the
@@ -19,11 +33,10 @@ names the secrets files provide. Nothing ambient. The connected database is
 then checked against its own `meta` stamp (migration 007), so a proxy pointed
 at the wrong world fails loudly instead of quietly editing production.
 
-Known gap (2026-07-20): the database does not record whether a conversation
-is a DM, so this tool resolves every channel by the guild rules (own row ->
-__default__). DMs additionally inherit __default_dm__ in the live bot; both
-policy rows are printed so the DM answer is readable, and `--dm` forces DM
-resolution for a single channel.
+Where a conversation lives (guild id/name, is_dm) is recorded by the bot on
+every message and backfilled by backfill_locations.py; DMs therefore resolve
+their own inheritance chain. `--dm` only forces it for conversations that
+haven't been located yet.
 """
 
 import argparse
@@ -77,9 +90,16 @@ async def open_database(environment: str) -> FaebotDatabase:
     return database
 
 
+def pool_of(database: FaebotDatabase):
+    """The connection pool, narrowed — open_database guarantees one exists."""
+    if database.pool is None:
+        sys.exit("database connection lost")
+    return database.pool
+
+
 async def load_channels(database: FaebotDatabase) -> list[dict]:
     """Every conversation with its name, newest activity first."""
-    async with database.pool.acquire() as connection:
+    async with pool_of(database).acquire() as connection:
         rows = await connection.fetch(
             "SELECT id, conversation_metadata, last_updated FROM conversations"
         )
@@ -110,7 +130,7 @@ UNKNOWN_GROUP = (
 
 async def load_overrides(database: FaebotDatabase) -> dict[str, dict]:
     """Raw channel_settings rows — which fields a channel sets for itself."""
-    async with database.pool.acquire() as connection:
+    async with pool_of(database).acquire() as connection:
         rows = await connection.fetch("SELECT * FROM channel_settings")
     return {row["conversation_id"]: dict(row) for row in rows}
 
@@ -161,7 +181,9 @@ async def show(environment: str, dm: bool) -> None:
                 # Per-channel DM resolution once recorded; --dm forces it for
                 # conversations that haven't healed yet.
                 is_dm = channel["is_dm"] if channel["is_dm"] is not None else dm
-                settings = await database.get_effective_settings(channel["id"], is_dm=is_dm)
+                settings = await database.get_effective_settings(
+                    channel["id"], is_dm=is_dm
+                )
                 own = overrides.get(channel["id"], {})
                 cells = []
                 for column in SETTINGS_COLUMNS:
@@ -189,7 +211,7 @@ async def show(environment: str, dm: bool) -> None:
             )
             print(f"{policy_id:<24} {values}")
         print()
-        print(f"  * = set on this channel   · = inherited   — = unset")
+        print("  * = set on this channel   · = inherited   — = unset")
         print(
             f"  resolution: {'DM (own → __default_dm__ → __default__)' if dm else 'guild (own → __default__)'}"
         )
@@ -243,7 +265,7 @@ def coerce(column: str, raw: str):
 
 async def load_constraints(database: FaebotDatabase) -> dict[str, str]:
     """The CHECK constraints, quoted back as hints — the DB is the truth."""
-    async with database.pool.acquire() as connection:
+    async with pool_of(database).acquire() as connection:
         rows = await connection.fetch(
             "SELECT pg_get_constraintdef(oid) AS definition FROM pg_constraint "
             "WHERE conrelid = 'channel_settings'::regclass AND contype = 'c'"
@@ -265,8 +287,9 @@ async def describe(database: FaebotDatabase, conversation_id: str) -> dict | Non
     return None
 
 
-async def count_inheritors(database: FaebotDatabase, column: str,
-                           policy_row: str) -> int:
+async def count_inheritors(
+    database: FaebotDatabase, column: str, policy_row: str
+) -> int:
     """How many conversations would feel a change to this policy row."""
     channels = await load_channels(database)
     overrides = await load_overrides(database)
@@ -296,14 +319,16 @@ def label_for(channel: dict | None, conversation_id: str) -> str:
     return f"{channel['name']} ({where})"
 
 
-async def write_setting(environment: str, conversation_id: str | None,
-                        property_name: str | None, value: str | None,
-                        clearing: bool) -> None:
+async def write_setting(
+    environment: str,
+    conversation_id: str | None,
+    property_name: str | None,
+    value: str | None,
+    clearing: bool,
+) -> None:
     """set/unset, with a ladder of errors that each teach the next step."""
     database = await open_database(environment)
     try:
-        command = "unset" if clearing else "set"
-
         if not conversation_id:
             sys.exit(
                 "which channel? pass --id <conversation id>\n"
@@ -342,8 +367,7 @@ async def write_setting(environment: str, conversation_id: str | None,
             hints = await load_constraints(database)
             inherited = "—"
             if conversation_id not in POLICY_ROWS:
-                policy = overrides.get(
-                    DEFAULT_DM_ROW if is_dm else DEFAULT_ROW, {})
+                policy = overrides.get(DEFAULT_DM_ROW if is_dm else DEFAULT_ROW, {})
                 fallback = policy.get(column)
                 if fallback is None:
                     fallback = overrides.get(DEFAULT_ROW, {}).get(column)
@@ -363,9 +387,11 @@ async def write_setting(environment: str, conversation_id: str | None,
             if conversation_id == DEFAULT_ROW:
                 # The base policy has nothing above it: clearing it drops the
                 # bot onto its emergency defaults, loudly. Not an unset target.
-                message.append("  pass --value <v>   (this row is the bottom of "
-                               "the chain — clearing it falls back to the bot's "
-                               "emergency defaults)")
+                message.append(
+                    "  pass --value <v>   (this row is the bottom of "
+                    "the chain — clearing it falls back to the bot's "
+                    "emergency defaults)"
+                )
             else:
                 message.append(
                     f"  pass --value <v>, or:  settings_cli.py unset --env {environment} "
@@ -374,12 +400,19 @@ async def write_setting(environment: str, conversation_id: str | None,
             sys.exit("\n".join(message))
 
         before = format_value(column, own.get(column))
-        new_value = None if clearing else coerce(column, value)
+        if clearing:
+            new_value = None
+        else:
+            # The ladder above exits when a set has no --value, so by here
+            # it is present; spelled out so the type checker agrees.
+            new_value = coerce(column, value or "")
 
         if conversation_id in POLICY_ROWS:
             affected = await count_inheritors(database, column, conversation_id)
-            print(f"⚠ {conversation_id} is a POLICY row — {affected} conversation(s) "
-                  f"inherit {column} from it")
+            print(
+                f"⚠ {conversation_id} is a POLICY row — {affected} conversation(s) "
+                f"inherit {column} from it"
+            )
 
         try:
             # A CHECK refusal is an EXPECTED outcome here (the user typed a bad
@@ -417,44 +450,59 @@ def main() -> None:
     # subcommand: `settings_cli.py show --env dev`.
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument(
-        "--env", required=True, choices=["dev", "prod"],
+        "--env",
+        required=True,
+        choices=["dev", "prod"],
         help="which database to talk to (reads DEV_/PROD_DATABASE_URL)",
     )
 
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
     show_parser = subparsers.add_parser(
-        "show", parents=[common], help="table of every channel's settings")
+        "show", parents=[common], help="table of every channel's settings"
+    )
     show_parser.add_argument(
-        "--dm", action="store_true",
+        "--dm",
+        action="store_true",
         help="resolve with DM rules for conversations whose kind isn't recorded",
     )
 
     # set/unset share --id and --property; each argument is optional so a
     # missing one can teach the next step instead of erroring blankly.
     write_common = argparse.ArgumentParser(add_help=False, parents=[common])
-    write_common.add_argument("--id", help="conversation id (never the name — "
-                                           "names duplicate across servers)")
-    write_common.add_argument("--property",
-                              help="model | frequency | history | template")
+    write_common.add_argument(
+        "--id",
+        help="conversation id (never the name — " "names duplicate across servers)",
+    )
+    write_common.add_argument(
+        "--property", help="model | frequency | history | template"
+    )
 
     set_parser = subparsers.add_parser(
-        "set", parents=[write_common], help="set one dial on one channel")
+        "set", parents=[write_common], help="set one dial on one channel"
+    )
     set_parser.add_argument("--value", help="the new value")
     subparsers.add_parser(
-        "unset", parents=[write_common],
+        "unset",
+        parents=[write_common],
         help="remove an override so the channel inherits again (and keeps "
-             "inheriting when the policy changes)")
+        "inheriting when the policy changes)",
+    )
 
     arguments = parser.parse_args()
 
     if arguments.command == "show":
         asyncio.run(show(arguments.env, arguments.dm))
     elif arguments.command in ("set", "unset"):
-        asyncio.run(write_setting(
-            arguments.env, arguments.id, arguments.property,
-            getattr(arguments, "value", None), clearing=arguments.command == "unset",
-        ))
+        asyncio.run(
+            write_setting(
+                arguments.env,
+                arguments.id,
+                arguments.property,
+                getattr(arguments, "value", None),
+                clearing=arguments.command == "unset",
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/settings_cli.py
+++ b/settings_cli.py
@@ -167,6 +167,12 @@ async def show(environment: str, dm: bool) -> None:
         for channel in channels:
             by_group.setdefault(group_of(channel), []).append(channel)
 
+        # Rows whose location was never recorded (or was erased by a
+        # shutdown-save) get resolved down the guild chain by default. That
+        # is a GUESS, and for a DM it is the wrong one — so count them and
+        # say so rather than printing a confident wrong number.
+        unknown_location = 0
+
         def group_sort_key(item):
             group, members = item
             unresolved = group in (DM_GROUP, UNKNOWN_GROUP)
@@ -179,8 +185,16 @@ async def show(environment: str, dm: bool) -> None:
             print("─" * len(header))
             for channel in members:
                 # Per-channel DM resolution once recorded; --dm forces it for
-                # conversations that haven't healed yet.
-                is_dm = channel["is_dm"] if channel["is_dm"] is not None else dm
+                # conversations that haven't healed yet. When is_dm is NULL we
+                # are guessing: the DM chain and the guild chain give different
+                # answers, so a stale DM printed 0.05/default while the live bot
+                # was really using 1.00/dm (2026-07-21). The bot is never wrong
+                # here — it reads the live channel object every message; only
+                # this table can be. Mark the row instead of guessing quietly.
+                location_known = channel["is_dm"] is not None
+                is_dm = channel["is_dm"] if location_known else dm
+                if not location_known:
+                    unknown_location += 1
                 settings = await database.get_effective_settings(
                     channel["id"], is_dm=is_dm
                 )
@@ -189,8 +203,9 @@ async def show(environment: str, dm: bool) -> None:
                 for column in SETTINGS_COLUMNS:
                     mark = "*" if own.get(column) is not None else "·"
                     cells.append((mark, format_value(column, settings[column])))
+                name_cell = ("?" if not location_known else "") + channel["name"][:23]
                 print(
-                    f"{channel['name'][:23]:<24} {channel['id']:<20} "
+                    f"{name_cell:<24} {channel['id']:<20} "
                     f"{cells[0][0]}{cells[0][1][:21]:<21} "
                     f"{cells[1][0]}{cells[1][1]:>5} "
                     f"{cells[2][0]}{cells[2][1]:>4} "
@@ -215,6 +230,21 @@ async def show(environment: str, dm: bool) -> None:
         print(
             f"  resolution: {'DM (own → __default_dm__ → __default__)' if dm else 'guild (own → __default__)'}"
         )
+        if unknown_location:
+            print()
+            print(
+                f"  ? = location not recorded ({unknown_location} row(s)) — resolved "
+                "as a guild channel."
+            )
+            print(
+                "      If one of these is a DM, its freq/template above are WRONG. "
+                "The bot is\n"
+                "      right regardless; only this table is guessing. Fix: post one "
+                "message there\n"
+                "      (it self-heals), or run backfill_locations.py — or re-run with "
+                "--dm to\n"
+                "      resolve these down the DM chain instead."
+            )
         print()
     finally:
         await database.close()
@@ -346,6 +376,18 @@ async def write_setting(
 
         overrides = await load_overrides(database)
         own = overrides.get(conversation_id, {})
+        # bool(None) is False, so an unrecorded location silently resolves down
+        # the guild chain. Harmless for the WRITE (a column is a column), but
+        # the current/inherited values we quote back would be from the wrong
+        # chain — say so before the reader trusts them.
+        if channel and channel["is_dm"] is None:
+            print(
+                f"  ! location not recorded for {heading} — resolving as a guild "
+                "channel.\n"
+                "    If this is a DM, the current/inherited values below are wrong.\n"
+                "    Fix: post one message there, or run backfill_locations.py",
+                file=sys.stderr,
+            )
         is_dm = bool(channel["is_dm"]) if channel else conversation_id == DEFAULT_DM_ROW
         effective = await database.get_effective_settings(conversation_id, is_dm=is_dm)
 

--- a/tests/test_faediscord.py
+++ b/tests/test_faediscord.py
@@ -3,7 +3,7 @@ import pytest
 import os
 import discord
 from unittest.mock import AsyncMock, Mock, patch
-from faediscord import Faebot, COMMAND_PREFIX, PROMPT_TEMPLATES, DEFAULT_TEMPLATE
+from faediscord import Faebot, COMMAND_PREFIX, PROMPT_TEMPLATES
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -90,7 +90,7 @@ class TestFaebot:
         assert isinstance(faebot.proxy_recent, dict)
         assert isinstance(faebot.recent_messages, dict)
         assert faebot.session is None
-        assert faebot.model == os.getenv("MODEL_NAME", "google/gemini-2.0-flash-001")
+        assert faebot.model == os.getenv("MODEL_NAME", "moonshotai/kimi-k2")
 
     @pytest.mark.asyncio
     async def test_on_ready(self, faebot):


### PR DESCRIPTION
**Step 5 of the see-and-edit story** (steps 1–4 shipped in #27/#28/#29): the full read/edit instrument, plus the small bot-side change that lets it name the servers it's talking about.

Draft while the deploy and prod verification happen — see the checklist at the bottom.

## The instrument — `settings_cli.py`

Talks to Postgres directly (through `fly proxy` for prod), so **no new attack surface on the bot** and the tool survives the move off fly.

- **`show`** — every channel × effective settings, grouped by server, each value marked as this channel's own override (`*`) or inherited (`·`), policy rows printed below.
- **`set` / `unset`** — one dial at a time: `--id --property --value`.
- **A ladder of errors that teach the next step**, rather than blank failures:
  - no `--id` → "run `show` to list them" (and: policy rows are ids too)
  - `--id` only → the four properties with their current values and origins
  - `--property` only → current, inherited, the **CHECK constraint quoted from the database**, and the `unset` hint — which doubles as a single-channel inspector that writes nothing
- **`unset` removes an override** so the channel keeps inheriting *as the policy changes*, rather than freezing today's default into the row. These are genuinely different operations and only the second one is usually wanted.
- **Policy rows** report blast radius (`inherited by: N conversation(s)`); `__default__` declines to advertise an `unset` it cannot honour, being the bottom of the chain.
- **CHECK violations are translated, not raised** — the database stays the real guard, the message just gets kind ("nothing was written").
- `--env` is required and then **verified against the database's own `meta` stamp** (migration 007), so a proxy pointed at the wrong world fails loudly.

Two anti-drift decisions worth calling out:

1. It calls the bot's own `get_effective_settings()` / `set_channel_setting()` — the NULL-inheritance chain has exactly one implementation.
2. It reads **only Discord-owned tables**. An earlier draft recovered guild ids by joining `captured_events`; that made a settings question depend on core's raw material, and it would have been *correct* for it to break when core takes that stream. Hence:

## Conversations learn where they live

- The bot now stamps `guild_id` / `guild_name` / `is_dm` into conversation metadata **on every message** — identity-shaped, so it rides in the blob with `name`/`conversants`, no migration. Self-healing, the same lazy mechanism that quietly cleaned up the pre-split settings ghosts.
- Carried back through `load_conversations` so a save after a restart cannot drop it, and written **only when known**, so a save from a path that never stamped them cannot erase a stamped one.
- Recording `is_dm` also closes a real gap: any reader can now resolve DM inheritance (`__default_dm__ → __default__`) without asking Discord.

**`backfill_locations.py`** fills the dormant channels that will never save again. Dry-run by default, idempotent, reports counts before/after. It is the only tool here that talks to Discord, and it uses **REST only — no gateway session**, so it cannot collide with the running bot's connection.

## Verification so far

- `show` / `set` / `unset` / the whole ladder exercised against **dev**; dev left exactly as found.
- Read-only paths exercised against **prod** (property listing, inspection, policy blast radius). No prod writes.
- Backfill run against prod: 10/10 conversations located, re-run reports "Nothing to backfill."
- Invalid values refused with the constraint quoted; nothing written.

## Before merge

- [x] Deploy (this PR's commit) — until then the running bot erases location on each active channel's next save; re-run `backfill_locations.py` afterwards if so
- [x] Verify a live channel self-heals its location after the deploy
- [x] One real prod `set` through the instrument
- [x] Observability column (posts/day from `captured_events`) — deliberately last; it's the deserves_reply calibration baseline and wants its own pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
